### PR TITLE
feat(std): add initial memory intrinsics

### DIFF
--- a/rt/src/lib.rs
+++ b/rt/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod mem;
+pub mod metadata;
+pub mod pointer;
+
 /// Retrieves of the type metadata of the first type parameter.
 ///
 /// Since Lume passes the metadata of type arguments after all other parameters,

--- a/rt/src/mem.rs
+++ b/rt/src/mem.rs
@@ -1,0 +1,40 @@
+unsafe extern "C" {
+    pub fn malloc(size: usize) -> *mut u8;
+
+    pub fn aligned_alloc(align: usize, size: usize) -> *mut u8;
+
+    pub fn realloc(ptr: *mut u8, new_size: usize) -> *mut u8;
+}
+
+/// Allocates the given amount of bytes using the global allocator.
+///
+/// The returned memory block may be larger than the requested size and
+/// it may not have it's content initialized and/or zeroed.
+#[unsafe(export_name = "std::mem::alloc")]
+#[expect(clippy::missing_safety_doc, reason = "early alpha stage")]
+pub unsafe extern "C" fn lumert_alloc(size: usize) -> *mut u8 {
+    unsafe { malloc(size) }
+}
+
+/// Allocates the given amount of bytes using the global allocator, aligned
+/// to the defined alignment.
+///
+/// The returned memory block may be larger than the requested size and
+/// it may not have it's content initialized and/or zeroed.
+#[unsafe(export_name = "std::mem::alloca")]
+#[expect(clippy::missing_safety_doc, reason = "early alpha stage")]
+pub unsafe extern "C" fn lumert_alloca(size: usize, align: usize) -> *mut u8 {
+    unsafe { aligned_alloc(align, size) }
+}
+
+/// Reallocates an existing pointer, so that the new memory block is at
+/// least the given length in bytes.
+///
+/// The returned memory block may be larger than the requested size. The content
+/// is guaranteed to be identical to the original memory block, up until the original
+/// memory block size.
+#[unsafe(export_name = "std::mem::realloc")]
+#[expect(clippy::missing_safety_doc, reason = "early alpha stage")]
+pub unsafe extern "C" fn lumert_realloc(ptr: *mut u8, new_size: usize) -> *mut u8 {
+    unsafe { realloc(ptr, new_size) }
+}

--- a/rt/src/metadata.rs
+++ b/rt/src/metadata.rs
@@ -1,0 +1,104 @@
+//! Type metadata structures.
+//!
+//! None of these structs are meant to be exported - they exist purely to
+//! better read type information from passed metadata arguments.
+
+use std::os::raw::c_char;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TypeId(usize);
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct FunctionId(usize);
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TypeMetadata {
+    /// Gets the fully qualified name of the type, including namespace.
+    pub full_name: *const c_char,
+
+    /// Gets the canonical size of the type, in bytes.
+    pub size: usize,
+
+    /// Gets the canonical alignment of the type, in bytes.
+    pub alignment: usize,
+
+    /// Gets the unique ID of the type, used mostly for internal referencing.
+    pub type_id: TypeId,
+
+    /// Gets all the fields defined on the type, in the order that they're declared.
+    pub fields: *const List<FieldMetadata>,
+
+    /// Gets all the methods defined on the type, in the order that they're declared.
+    pub methods: *const List<MethodMetadata>,
+
+    /// Gets all the type arguments defined on the type, in the order
+    /// that they're declared.
+    pub type_arguments: *const List<TypeMetadata>,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct FieldMetadata {
+    /// Gets the name of the field.
+    pub name: *const c_char,
+
+    /// Gets the type of the field.
+    pub ty: *const TypeMetadata,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct MethodMetadata {
+    /// Gets the fully-qualified name of the method, including namespace and type name.
+    pub full_name: *const c_char,
+
+    /// Gets the unique ID of the method, used mostly for internal referencing.
+    pub func_id: FunctionId,
+
+    /// Gets all the parameters defined on the method, in the order that they're declared.
+    pub parameters: *const List<ParameterMetadata>,
+
+    /// Gets all the type parameters defined on the method, in the order
+    /// that they're declared.
+    pub type_parameters: *const List<TypeParameterMetadata>,
+
+    /// Gets the return type of the method.
+    pub return_type: *const TypeMetadata,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ParameterMetadata {
+    /// Gets the name of the parameter.
+    pub name: *const c_char,
+
+    /// Gets the type of the field.
+    pub ty: *const TypeMetadata,
+
+    /// Determines whether the parameter is a variable parameter.
+    pub vararg: bool,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TypeParameterMetadata {
+    /// Gets the name of the type parameter.
+    pub name: *const c_char,
+
+    /// Gets all the constraints defined on the type parameter, in the order
+    /// that they're declared.
+    pub constraints: *const List<TypeMetadata>,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct List<T> {
+    /// Defines the amount of items within the list.
+    pub length: usize,
+
+    /// Defines all the items in the list.
+    pub items: [T; 0],
+}

--- a/rt/src/pointer.rs
+++ b/rt/src/pointer.rs
@@ -1,0 +1,33 @@
+use crate::metadata::TypeMetadata;
+
+unsafe extern "C" {
+    pub fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
+}
+
+/// Reads an existing value from the memory location the current pointer is pointing to,
+/// offset by the given amount of bytes.
+#[unsafe(export_name = "std::mem::ptr_read")]
+#[expect(clippy::missing_safety_doc, reason = "early alpha stage")]
+pub unsafe extern "C" fn lumert_ptr_read(ptr: *mut u8, offset: usize, metadata: *const TypeMetadata) -> *mut u8 {
+    let value_size = unsafe { metadata.read().size };
+    let dest = unsafe { crate::mem::lumert_alloc(value_size) };
+
+    unsafe { memcpy(dest, ptr.byte_add(offset), value_size) };
+
+    dest
+}
+
+/// Writes a new value to the memory location the current pointer is pointing to, offset by
+/// the given amount of bytes.
+#[unsafe(export_name = "std::mem::ptr_write")]
+#[expect(clippy::missing_safety_doc, reason = "early alpha stage")]
+pub unsafe extern "C" fn lumert_ptr_write(
+    ptr: *mut u8,
+    value: *const u8,
+    offset: usize,
+    metadata: *const TypeMetadata,
+) {
+    let value_size = unsafe { metadata.read().size };
+
+    unsafe { memcpy(ptr.byte_add(offset), value, value_size) };
+}

--- a/std/mem/alloc.lm
+++ b/std/mem/alloc.lm
@@ -1,0 +1,25 @@
+namespace std::mem
+
+/// Allocates the given amount of bytes using the global allocator.
+///
+/// The returned memory block may be larger than the requested size and
+/// it may not have it's content initialized and/or zeroed.
+pub fn external alloc<T>(size: UInt64) -> Pointer<T>
+
+/// Allocates the given amount of bytes using the global allocator, aligned
+/// to the defined alignment.
+///
+/// The returned memory block may be larger than the requested size and
+/// it may not have it's content initialized and/or zeroed.
+pub fn external alloca<T>(size: UInt64, align: UInt64) -> Pointer<T>
+
+/// Reallocates an existing pointer to a new size.
+pub fn external realloc<T>(ptr: Pointer<T>, size: UInt64) -> Pointer<T>
+
+/// Reads an existing value from the memory location the current pointer is pointing to,
+/// offset by the given amount of bytes.
+pub fn external ptr_read<T>(ptr: Pointer<T>, offset: UInt64) -> T
+
+/// Writes a new value to the memory location the current pointer is pointing to,
+/// offset by the given amount of bytes.
+pub fn external ptr_write<T>(ptr: Pointer<T>, value: T, offset: UInt64)

--- a/std/pointer.lm
+++ b/std/pointer.lm
@@ -1,8 +1,44 @@
 namespace std
 
+import std::mem (ptr_read, ptr_write)
+
 /// Defines a raw pointer, which can be used to access memory directly.
 ///
 /// Pointers cannot be created manually - they can only be created by the compiler itself, as a result
 /// of creating a built-in type or some other memory allocation.
-struct builtin Pointer
+struct builtin Pointer<T>
 { }
+
+impl<T> Pointer<T> {
+    /// Writes a new value to the memory location the current pointer is pointing to.
+    pub fn read(self) -> T {
+        return ptr_read<T>(self, 0_u64);
+    }
+
+    /// Writes a new value to the memory location the current pointer is pointing to.
+    pub fn write(self, value: T) {
+        ptr_write<T>(self, value, 0_u64);
+    }
+
+    /// Reads the value from the memory location the current pointer is pointing to,
+    /// offset by the given amount of items.
+    ///
+    /// This method does not read with a byte offset. The byte offset of this method
+    /// will be `ptr + (size_of<T> * offset)`.
+    pub fn read_offset(self, offset: UInt64) -> T {
+        let size = std::type_of<T>().size;
+
+        return ptr_read<T>(self, offset * size);
+    }
+
+    /// Writes a new value to the memory location the current pointer is pointing to,
+    /// offset by the given amount of items.
+    ///
+    /// This method does not write with a byte offset. The byte offset of this method
+    /// will be `ptr + (size_of<T> * offset)`.
+    pub fn write_offset(self, value: T, offset: UInt64) {
+        let size = std::type_of<T>().size;
+
+        ptr_write<T>(self, value, offset * size);
+    }
+}

--- a/std/type.lm
+++ b/std/type.lm
@@ -63,3 +63,5 @@ pub struct TypeParameter {
     /// that they're declared.
     pub constraints: Array<Type>;
 }
+
+pub fn external type_of<T>() -> Type


### PR DESCRIPTION
Adds the first memory intrinsics to the standard library, such as:
- memory management: `alloc`, `alloca`, `realloc`,
- pointer I/O: `ptr_read`, `ptr_write`
- expanded `Pointer`: `read`, `write`, `read_offset`, `write_offset`