### PR TITLE
refactor: remove unstable Rust feature flags

### DIFF
--- a/compiler/lume_cli/src/lib.rs
+++ b/compiler/lume_cli/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(exclusive_wrapper)]
-
 pub(crate) mod commands;
 pub(crate) mod error;
 

--- a/compiler/lume_errors/src/lib.rs
+++ b/compiler/lume_errors/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::arc_with_non_send_sync)]
-#![feature(negative_impls)]
 
 pub const ERROR_GUARANTEED_CODE: &str = "FINAL_ERROR";
 

--- a/compiler/lume_hir/src/lib.rs
+++ b/compiler/lume_hir/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(debug_closure_helpers)]
-
 use std::fmt::Display;
 
 use lume_macros::Node;

--- a/compiler/lume_hir/src/map.rs
+++ b/compiler/lume_hir/src/map.rs
@@ -118,17 +118,8 @@ impl Map {
     }
 }
 
-#[expect(
-    clippy::missing_fields_in_debug,
-    reason = "we explicitly don't want imports, since they clutter tests"
-)]
 impl Debug for Map {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Map")
-            .field("package", &self.package)
-            .field("items", &self.items)
-            .field("statements", &self.statements)
-            .field("expressions", &self.expressions)
-            .finish()
+        self.pretty_fmt(f)
     }
 }

--- a/compiler/lume_infer/src/define.rs
+++ b/compiler/lume_infer/src/define.rs
@@ -865,7 +865,7 @@ impl TyInferCtx {
         let parent = DefId::Item(struct_def.id);
 
         for field in &struct_def.fields {
-            let _ = tree.try_insert(field.id, parent);
+            let _ = tree.insert(field.id, parent);
 
             if let Some(default) = field.default_value {
                 self.define_expr_scope(tree, default, field.id)?;
@@ -883,7 +883,7 @@ impl TyInferCtx {
         let parent = DefId::Item(trait_def.id);
 
         for method in &trait_def.methods {
-            let _ = tree.try_insert(method.id, parent);
+            let _ = tree.insert(method.id, parent);
 
             if let Some(block) = &method.block {
                 self.define_block_scope(tree, block, method.id)?;
@@ -901,7 +901,7 @@ impl TyInferCtx {
         let parent = DefId::Item(implementation.id);
 
         for method in &implementation.methods {
-            let _ = tree.try_insert(method.id, parent);
+            let _ = tree.insert(method.id, parent);
 
             if let Some(block) = &method.block {
                 self.define_block_scope(tree, block, method.id)?;
@@ -919,7 +919,7 @@ impl TyInferCtx {
         let parent = DefId::Item(trait_impl.id);
 
         for method in &trait_impl.methods {
-            let _ = tree.try_insert(method.id, parent);
+            let _ = tree.insert(method.id, parent);
 
             self.define_block_scope(tree, &method.block, method.id)?;
         }
@@ -961,7 +961,7 @@ impl TyInferCtx {
         parent: DefId,
     ) -> Result<()> {
         let stmt_id = DefId::Statement(stmt);
-        let _ = tree.try_insert(stmt_id, parent);
+        let _ = tree.insert(stmt_id, parent);
 
         let stmt = self.hir.statement(stmt).unwrap();
 
@@ -1013,7 +1013,7 @@ impl TyInferCtx {
         parent: DefId,
     ) -> Result<()> {
         let expr_id = DefId::Expression(expr);
-        let _ = tree.try_insert(expr_id, parent);
+        let _ = tree.insert(expr_id, parent);
 
         let expr = self.hir.expression(expr).unwrap();
 
@@ -1106,7 +1106,7 @@ impl TyInferCtx {
         parent: DefId,
     ) -> Result<()> {
         let def_id = pat.id;
-        let _ = tree.try_insert(def_id, parent);
+        let _ = tree.insert(def_id, parent);
 
         match &pat.kind {
             lume_hir::PatternKind::Literal(_)

--- a/compiler/lume_infer/src/lib.rs
+++ b/compiler/lume_infer/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(map_try_insert)]
-
 use std::{collections::BTreeMap, fmt::Debug, ops::Deref};
 
 use error_snippet::Result;

--- a/compiler/lume_parser/src/expr.rs
+++ b/compiler/lume_parser/src/expr.rs
@@ -713,6 +713,14 @@ impl Parser {
     /// Parses a literal value expression on the current cursor position.
     #[tracing::instrument(level = "TRACE", skip(self), err)]
     pub(super) fn parse_literal(&mut self) -> Result<Expression> {
+        let literal = self.parse_literal_inner()?;
+
+        Ok(Expression::Literal(Box::new(literal)))
+    }
+
+    /// Parses a literal value expression on the current cursor position.
+    #[tracing::instrument(level = "TRACE", skip(self), err)]
+    pub(super) fn parse_literal_inner(&mut self) -> Result<Literal> {
         let token = self.token();
         let location: Location = token.index.into();
 
@@ -721,7 +729,9 @@ impl Parser {
                 let mut value = token.value.unwrap();
 
                 // Remove all underscores from the literal
-                value.remove_matches("_");
+                while let Some(idx) = value.find("\"") {
+                    value.remove(idx);
+                }
 
                 // Remove radix prefixes, as `from_str_radix` does not support them
                 // being included.
@@ -798,7 +808,7 @@ impl Parser {
 
         self.skip();
 
-        Ok(Expression::Literal(Box::new(literal)))
+        Ok(literal)
     }
 
     /// Parses a unary expression on the current cursor position.

--- a/compiler/lume_parser/src/lib.rs
+++ b/compiler/lume_parser/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(box_into_inner)]
-#![feature(string_remove_matches)]
-
 use std::sync::Arc;
 
 use crate::errors::*;

--- a/compiler/lume_parser/src/pattern.rs
+++ b/compiler/lume_parser/src/pattern.rs
@@ -24,11 +24,9 @@ impl Parser {
 
     #[tracing::instrument(level = "TRACE", skip(self), err)]
     fn parse_literal_pattern(&mut self) -> Result<Pattern> {
-        let Expression::Literal(literal_expr) = self.parse_literal()? else {
-            unreachable!()
-        };
+        let literal_expr = self.parse_literal_inner()?;
 
-        Ok(Pattern::Literal(Box::into_inner(literal_expr)))
+        Ok(Pattern::Literal(literal_expr))
     }
 
     #[tracing::instrument(level = "TRACE", skip(self), err)]

--- a/compiler/lume_query_macros/src/cached_query.rs
+++ b/compiler/lume_query_macros/src/cached_query.rs
@@ -137,7 +137,9 @@ fn parse_hash_keys(expr: &syn::Meta) -> proc_macro2::TokenStream {
         syn::Meta::List(_) => panic!("list expressions are not supported"),
     };
 
-    keys.remove_matches("\"");
+    while let Some(idx) = keys.find("\"") {
+        keys.remove(idx);
+    }
 
     let ident = syn::parse_str::<syn::Expr>(&keys).expect("unable to parse \"key\" expression");
 

--- a/compiler/lume_query_macros/src/lib.rs
+++ b/compiler/lume_query_macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(string_remove_matches)]
-
 mod cached_query;
 
 use proc_macro::TokenStream;

--- a/compiler/lume_typech/src/lib.rs
+++ b/compiler/lume_typech/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(map_try_insert)]
-
 use std::ops::Deref;
 
 use lume_errors::DiagCtx;

--- a/tools/manifold/src/diff.rs
+++ b/tools/manifold/src/diff.rs
@@ -10,8 +10,17 @@ use similar::{ChangeTag, TextDiff};
 use crate::{TestFailureCallback, TestResult};
 
 pub(crate) fn diff_output_of(output: String, path: PathBuf, output_path: PathBuf) -> Result<TestResult> {
+    let new_extension = if let Some(existing_ext) = output_path.extension().and_then(|ext| ext.to_str()) {
+        let mut ext = existing_ext.to_string();
+        ext.push_str(".new");
+
+        ext
+    } else {
+        String::from("new")
+    };
+
     let mut output_path_new = output_path.clone();
-    output_path_new.add_extension("new");
+    output_path_new.set_extension(new_extension);
 
     if output_path.is_file() {
         let expected_output = std::fs::read_to_string(&output_path).map_err(IntoDiagnostic::into_diagnostic)?;

--- a/tools/manifold/src/hir.rs
+++ b/tools/manifold/src/hir.rs
@@ -44,12 +44,5 @@ fn build_hir(path: &PathBuf, content: String) -> String {
         }
     };
 
-    let mut opts = std::fmt::FormattingOptions::new();
-    opts.alternate(true);
-
-    let mut writer = String::new();
-    let mut fmt = opts.create_formatter(&mut writer);
-    map.pretty_fmt(&mut fmt).unwrap();
-
-    writer
+    format!("{map:#?}")
 }

--- a/tools/manifold/src/lib.rs
+++ b/tools/manifold/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(formatting_options)]
-#![feature(path_add_extension)]
-
 mod diff;
 mod hir;
 mod ui;

--- a/tools/manifold/src/ui.rs
+++ b/tools/manifold/src/ui.rs
@@ -28,8 +28,8 @@ pub(crate) fn run_test(path: PathBuf) -> Result<TestResult> {
     let mut stderr_path = path.clone();
     stderr_path.set_extension("stderr");
 
-    let mut stderr_new_path = stderr_path.clone();
-    stderr_new_path.add_extension("new");
+    let mut stderr_new_path = path.clone();
+    stderr_new_path.set_extension("stderr.new");
 
     let file_content = std::fs::read_to_string(&path).map_err(IntoDiagnostic::into_diagnostic)?;
 


### PR DESCRIPTION
Removing unstable feature flags is the first, and maybe only, step to making the Lume compiler accessible to non-nightly Rust builds. 