### PR TITLE
fix: allow blanket trait implementations

### DIFF
--- a/compiler/lume_infer/src/define.rs
+++ b/compiler/lume_infer/src/define.rs
@@ -343,6 +343,9 @@ impl TyInferCtx {
                 lume_types::MethodKind::TraitImplementation,
             )?;
 
+            let trait_use_ty = self.tdb_mut().use_mut(trait_impl.use_id.unwrap()).unwrap();
+            trait_use_ty.methods.push(method_id);
+
             method.method_id = Some(method_id);
         }
 

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -65,7 +65,7 @@ impl<'mir> FunctionTransformer<'mir> {
     pub fn define(transformer: &'mir ModuleTransformer, id: FunctionId, func: &lume_tir::Function) -> Function {
         let mut transformer = Self {
             transformer,
-            func: Function::new(id, func.name.to_string(), func.location),
+            func: Function::new(id, func.name_as_str(), func.location),
             variables: HashMap::new(),
         };
 
@@ -78,7 +78,7 @@ impl<'mir> FunctionTransformer<'mir> {
     pub fn transform(transformer: &'mir ModuleTransformer, id: FunctionId, func: &lume_tir::Function) -> Function {
         let mut transformer = Self {
             transformer,
-            func: Function::new(id, func.name.to_string(), func.location),
+            func: Function::new(id, func.name_as_str(), func.location),
             variables: HashMap::new(),
         };
 

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -208,7 +208,7 @@ impl<'mir> FunctionTransformer<'mir> {
         // then we pass the address of the stack slot to the function.
         for (arg, param) in args.iter_mut().zip(params.iter()) {
             // If the parameter isn't generic, we let it be.
-            if !param.ty.is_generic {
+            if !param.ty.is_generic && !param.ty.kind.is_reference_type() {
                 continue;
             }
 

--- a/compiler/lume_tir/src/lib.rs
+++ b/compiler/lume_tir/src/lib.rs
@@ -109,7 +109,8 @@ impl std::fmt::Display for PathSegment {
                         "<{}>",
                         type_arguments
                             .iter()
-                            .map(std::string::ToString::to_string)
+                            .enumerate()
+                            .map(|(idx, _)| format!("`{}", idx + 1))
                             .collect::<Vec<_>>()
                             .join(", ")
                     )?;
@@ -162,6 +163,12 @@ pub struct Function {
     pub return_type: TypeRef,
     pub block: Option<Block>,
     pub location: Location,
+}
+
+impl Function {
+    pub fn name_as_str(&self) -> String {
+        format!("{:+}", self.name)
+    }
 }
 
 #[derive(Debug, Clone, Eq)]

--- a/compiler/lume_tir_lower/src/expr.rs
+++ b/compiler/lume_tir_lower/src/expr.rs
@@ -126,6 +126,12 @@ impl LowerFunction<'_> {
         let callable = self.lower.tcx.lookup_callable(expr)?;
         let instantiated_signature = self.lower.tcx.instantiate_call_expression(callable.signature(), expr)?;
 
+        tracing::debug!(
+            "resolved callable `{:+}` from call expression `{}`",
+            callable.name(),
+            expr.name()
+        );
+
         let function = match callable {
             lume_typech::query::Callable::Function(call) => {
                 #[cfg(debug_assertions)]

--- a/compiler/lume_typech/src/check/lookup.rs
+++ b/compiler/lume_typech/src/check/lookup.rs
@@ -1,5 +1,5 @@
 use error_snippet::Result;
-use lume_types::{TypeKind, TypeRef, UserType};
+use lume_types::{TypeKind, TypeRef, Use, UserType};
 
 use crate::TyCheckCtx;
 
@@ -34,6 +34,9 @@ impl TyCheckCtx {
     /// Determines whether the given [`TypeRef`], `ty`, implements the given trait, `trait_id`.
     #[tracing::instrument(level = "TRACE", skip(self), err, ret)]
     pub fn trait_impl_by(&self, trait_id: &TypeRef, ty: &TypeRef) -> Result<bool> {
+        #[cfg(debug_assertions)]
+        self.tdb().ty_expect_trait(trait_id.instance_of)?;
+
         if let Some(type_param) = self.tdb().type_as_param(ty.instance_of) {
             for constraint in &type_param.constraints {
                 if self.check_type_compatibility(constraint, trait_id)? {
@@ -42,15 +45,45 @@ impl TyCheckCtx {
             }
         }
 
+        // Check for direct trait implementations on the target type.
         for use_ in self.tdb().uses_on(ty) {
             if &use_.trait_ == trait_id {
                 // Make sure the given "trait" is actually a trait.
-                self.tdb().ty_expect_trait(trait_id.instance_of)?;
+                self.tdb().ty_expect_trait(use_.trait_.instance_of)?;
 
                 return Ok(true);
             }
         }
 
+        // If no direct implementations exist, attempt to find any blanket
+        // implementations which might encapsulate the target type.
+        for blanket_impl in self.trait_blanket_impls(trait_id) {
+            if self.check_type_compatibility(ty, &blanket_impl.target)? {
+                return Ok(true);
+            }
+        }
+
         Ok(false)
+    }
+
+    /// Determines whether the given trait [`TypeRef`] has been blanket implemented anywhere.
+    #[tracing::instrument(level = "TRACE", skip(self), err, ret)]
+    pub fn is_trait_blanket_impl(&self, trait_type: &TypeRef) -> Result<bool> {
+        for trait_impl in self.tdb().uses_of(trait_type) {
+            if self.is_type_parameter(&trait_impl.target)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Returns an iterator of all trait implementations of the given trait [`TypeRef`],
+    /// which are blanket implementations.
+    #[tracing::instrument(level = "TRACE", skip(self))]
+    pub fn trait_blanket_impls(&self, trait_type: &TypeRef) -> impl Iterator<Item = &Use> {
+        self.tdb()
+            .uses_of(trait_type)
+            .filter(|trait_impl| self.is_type_parameter(&trait_impl.target).unwrap_or(false))
     }
 }

--- a/compiler/lume_types/src/lib.rs
+++ b/compiler/lume_types/src/lib.rs
@@ -293,12 +293,12 @@ pub struct Field {
     pub field_type: TypeRef,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MethodKind {
     Implementation,
     Intrinsic,
-    TraitDefinition,
     TraitImplementation,
+    TraitDefinition,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -400,6 +400,7 @@ pub struct Use {
     pub trait_: TypeRef,
     pub target: TypeRef,
     pub type_parameters: Vec<TypeParameterId>,
+    pub methods: Vec<MethodId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1448,6 +1449,7 @@ impl TypeDatabaseContext {
             trait_: TypeRef::unknown(),
             target: TypeRef::unknown(),
             type_parameters: Vec::new(),
+            methods: Vec::new(),
         });
 
         id

--- a/compiler/lume_types/src/lib.rs
+++ b/compiler/lume_types/src/lib.rs
@@ -1349,10 +1349,16 @@ impl TypeDatabaseContext {
         methods.into_iter().flatten()
     }
 
-    /// Gets an iterator which iterates all [`Item`]-instances where
+    /// Gets an iterator which iterates all [`Use`]-instances where
     /// the item refers to a [`Use`], which are implementation on the given [`Item`].
     pub fn uses_on(&self, on: &TypeRef) -> impl Iterator<Item = &Use> {
         self.uses().filter(move |u| &u.target == on)
+    }
+
+    /// Gets an iterator which iterates all [`Use`]-instances which implement
+    /// the given trait item.
+    pub fn uses_of(&self, on: &TypeRef) -> impl Iterator<Item = &Use> {
+        self.uses().filter(move |u| &u.trait_ == on)
     }
 
     /// Attempts to find a [`Type`] with the given name, if any.

--- a/tests/ui/smoke/generic_field_type.lm
+++ b/tests/ui/smoke/generic_field_type.lm
@@ -1,0 +1,6 @@
+//# test-outcome=success
+
+struct Foo<T> {
+    a: T;
+    b: T;
+}

--- a/tests/ui/smoke/trait_blanket_impl.lm
+++ b/tests/ui/smoke/trait_blanket_impl.lm
@@ -1,0 +1,9 @@
+//# test-outcome=success
+
+trait Foo {
+    pub fn foo(self) { }
+}
+
+use<T> Foo in T {
+    pub fn foo(self) { }
+}

--- a/tests/ui/smoke/trait_blanket_impl_invocation.lm
+++ b/tests/ui/smoke/trait_blanket_impl_invocation.lm
@@ -1,0 +1,15 @@
+//# test-outcome=success
+
+trait Foo {
+    pub fn foo(self) { }
+}
+
+use<T> Foo in T {
+    pub fn foo(self) { }
+}
+
+fn bar() {
+    let a: Int32 = 0_i32;
+
+    a.foo();
+}

--- a/tests/ui/typech/call_trait_method_unbound.stderr
+++ b/tests/ui/typech/call_trait_method_unbound.stderr
@@ -1,7 +1,7 @@
-× error[LM4113]: could not find method
-   ╭─[call_trait_method_unbound.lm:8:24]
+× error[LM4002]: trait is not implemented
+   ╭─[call_trait_method_unbound.lm:8:20]
  7 │ fn foo<T>(val: T) {
  8 │     let _: Int32 = val.value();
-   │                        ^^^^^^ could not find method value on type T
+   │                    ^^^ the trait B is not implemented for the type T
  9 │ }
    ╰──


### PR DESCRIPTION
Code like the following will now work without issue:
```lm
trait Foo {
    pub fn bar(self) { }
}

use<T> Foo in T { }

fn main() {
    0.bar();
}
```