### PR TITLE
feat: dynamic dispatch over methods over type arguments

### DIFF
--- a/compiler/lume_codegen/src/cranelift/dwarf.rs
+++ b/compiler/lume_codegen/src/cranelift/dwarf.rs
@@ -14,7 +14,7 @@ use gimli::{DwLang, Encoding, LineEncoding, Register, RunTimeEndian, SectionId};
 use indexmap::IndexMap;
 use lume_errors::Result;
 use lume_mir::{Function, TypeRef};
-use lume_span::{Location, SourceFileId, hash_id};
+use lume_span::{DefId, Location, SourceFileId, hash_id};
 use lume_type_metadata::TypeMetadataId;
 
 use crate::Context;
@@ -84,8 +84,8 @@ pub(crate) struct RootDebugContext<'ctx> {
     endianess: RunTimeEndian,
     stack_register: Register,
 
-    func_entries: IndexMap<lume_mir::FunctionId, UnitEntryId>,
-    func_locs: IndexMap<lume_mir::FunctionId, Location>,
+    func_entries: IndexMap<DefId, UnitEntryId>,
+    func_locs: IndexMap<DefId, Location>,
     source_locations: IndexMap<SourceFileId, FileId>,
 
     declared_types: HashMap<TypeRef, UnitEntryId>,
@@ -194,7 +194,7 @@ impl<'ctx> RootDebugContext<'ctx> {
     /// Defines the start and size of the function to the matching DWARF tag.
     pub(crate) fn define_function(
         &mut self,
-        func_id: lume_mir::FunctionId,
+        func_id: DefId,
         decl_id: FuncId,
         backend: &CraneliftBackend,
         ctx: &cranelift::codegen::Context,

--- a/compiler/lume_codegen/src/cranelift/mod.rs
+++ b/compiler/lume_codegen/src/cranelift/mod.rs
@@ -52,8 +52,6 @@ impl<'ctx> Backend<'ctx> for CraneliftBackend<'ctx> {
 
     #[tracing::instrument(level = "DEBUG", skip(self), err)]
     fn generate(&mut self) -> lume_errors::Result<CompiledModule> {
-        self.declare_type_metadata();
-
         let functions = std::mem::take(&mut self.context.mir.functions);
 
         for func in functions.values() {
@@ -62,6 +60,9 @@ impl<'ctx> Backend<'ctx> for CraneliftBackend<'ctx> {
             self.declared_funcs
                 .insert(func.id, DeclaredFunction { id: func_id, sig });
         }
+
+        self.context.mir.functions = functions;
+        self.declare_type_metadata();
 
         let mut ctx = self.module_mut().make_context();
         let mut builder_ctx = FunctionBuilderContext::new();
@@ -72,7 +73,7 @@ impl<'ctx> Backend<'ctx> for CraneliftBackend<'ctx> {
             None
         };
 
-        for func in functions.values() {
+        for func in self.context.mir.functions.values() {
             if func.signature.external {
                 continue;
             }

--- a/compiler/lume_codegen/src/cranelift/mod.rs
+++ b/compiler/lume_codegen/src/cranelift/mod.rs
@@ -17,7 +17,7 @@ use error_snippet::SimpleDiagnostic;
 use indexmap::{IndexMap, IndexSet};
 use lume_errors::Result;
 use lume_mir::{BlockBranchSite, RegisterId, SlotId};
-use lume_span::Location;
+use lume_span::{DefId, Location};
 
 use crate::{Backend, CompiledModule, Context};
 use dwarf::RootDebugContext;
@@ -37,7 +37,7 @@ pub(crate) struct CraneliftBackend<'ctx> {
     context: Context<'ctx>,
     module: Option<Arc<RwLock<ObjectModule>>>,
 
-    declared_funcs: IndexMap<lume_mir::FunctionId, DeclaredFunction>,
+    declared_funcs: IndexMap<DefId, DeclaredFunction>,
     intrinsics: IntrinsicFunctions,
 
     static_data: RwLock<HashMap<String, DataId>>,
@@ -611,7 +611,7 @@ impl<'ctx> LowerFunction<'ctx> {
         self.builder.ins().symbol_value(self.backend.cl_ptr_type(), local_id)
     }
 
-    pub(crate) fn call(&mut self, func: lume_mir::FunctionId, args: &[lume_mir::Operand]) -> &[Value] {
+    pub(crate) fn call(&mut self, func: DefId, args: &[lume_mir::Operand]) -> &[Value] {
         let cl_func_id = self.backend.declared_funcs.get(&func).unwrap().id;
         let cl_func_ref = self.get_func(cl_func_id);
 

--- a/compiler/lume_infer/src/define.rs
+++ b/compiler/lume_infer/src/define.rs
@@ -113,7 +113,6 @@ static INTRINSIC_METHODS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "std::Double::-",
         "std::Double::*",
         "std::Double::/",
-        "std::Boolean::to_string",
         "std::Int8::to_string",
         "std::Int16::to_string",
         "std::Int32::to_string",

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use indexmap::{IndexMap, IndexSet};
-use lume_span::{Interned, Location};
+use lume_span::{DefId, Interned, Location};
 use lume_type_metadata::{StaticMetadata, TypeMetadata};
 
 /// Represents a map of all functions within a compilation
@@ -10,7 +10,7 @@ use lume_type_metadata::{StaticMetadata, TypeMetadata};
 #[derive(Default, Debug, Clone)]
 pub struct ModuleMap {
     pub metadata: StaticMetadata,
-    pub functions: IndexMap<FunctionId, Function>,
+    pub functions: IndexMap<DefId, Function>,
 }
 
 impl ModuleMap {
@@ -27,7 +27,7 @@ impl ModuleMap {
     /// # Panics
     ///
     /// Panics if the given ID is invalid or out of bounds.
-    pub fn function(&self, id: FunctionId) -> &Function {
+    pub fn function(&self, id: DefId) -> &Function {
         self.functions.get(&id).unwrap()
     }
 
@@ -36,7 +36,7 @@ impl ModuleMap {
     /// # Panics
     ///
     /// Panics if the given ID is invalid or out of bounds.
-    pub fn function_mut(&mut self, id: FunctionId) -> &mut Function {
+    pub fn function_mut(&mut self, id: DefId) -> &mut Function {
         self.functions.get_mut(&id).unwrap()
     }
 }
@@ -48,20 +48,6 @@ impl std::fmt::Display for ModuleMap {
         }
 
         Ok(())
-    }
-}
-
-/// Unique identifier for a function within a module.
-///
-/// [`FunctionId`]s refer to the specific MIR function which
-/// is being referred to, so it can be used to optimize call
-/// site expressions.
-#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FunctionId(pub usize);
-
-impl std::fmt::Display for FunctionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "F{:?}", self.0)
     }
 }
 
@@ -127,7 +113,7 @@ impl std::fmt::Display for Parameter {
 /// functions and methods are represented by this struct.
 #[derive(Debug, Clone)]
 pub struct Function {
-    pub id: FunctionId,
+    pub id: DefId,
     pub name: String,
     pub signature: Signature,
 
@@ -142,7 +128,7 @@ pub struct Function {
 }
 
 impl Function {
-    pub fn new(id: FunctionId, name: String, location: Location) -> Self {
+    pub fn new(id: DefId, name: String, location: Location) -> Self {
         Function {
             id,
             name,
@@ -917,7 +903,7 @@ pub enum DeclarationKind {
     Intrinsic { name: Intrinsic, args: Vec<Operand> },
 
     /// Represents a call to a function.
-    Call { func_id: FunctionId, args: Vec<Operand> },
+    Call { func_id: DefId, args: Vec<Operand> },
 }
 
 impl Declaration {

--- a/compiler/lume_mir_lower/src/expr.rs
+++ b/compiler/lume_mir_lower/src/expr.rs
@@ -1,4 +1,3 @@
-use lume_mir::FunctionId;
 use lume_span::Location;
 
 use crate::FunctionTransformer;
@@ -171,8 +170,6 @@ impl FunctionTransformer<'_> {
     }
 
     fn call_expression(&mut self, expr: &lume_tir::Call) -> lume_mir::Operand {
-        let func_id = FunctionId(expr.function.as_usize());
-
         let args = expr
             .arguments
             .iter()
@@ -188,7 +185,7 @@ impl FunctionTransformer<'_> {
             ret_ty = lume_mir::Type::pointer(ret_ty);
         }
 
-        self.call(func_id, args, ret_ty, expr.location)
+        self.call(expr.function, args, ret_ty, expr.location)
     }
 
     fn intrinsic_call(&mut self, expr: &lume_tir::IntrinsicCall) -> lume_mir::Operand {

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -5,8 +5,8 @@ pub(crate) mod ty;
 
 use std::collections::HashMap;
 
-use lume_mir::{Function, FunctionId, ModuleMap, RegisterId};
-use lume_span::Location;
+use lume_mir::{Function, ModuleMap, RegisterId};
+use lume_span::{DefId, Location};
 use lume_typech::TyCheckCtx;
 
 /// Defines a transformer which will lower a typed HIR map into an MIR map.
@@ -37,14 +37,14 @@ impl<'tcx> ModuleTransformer<'tcx> {
     }
 
     fn define_callable(&mut self, func: &lume_tir::Function) {
-        let id = lume_mir::FunctionId(func.id.as_usize());
+        let id = func.id;
         let func = FunctionTransformer::define(self, id, func);
 
         self.mir.functions.insert(id, func);
     }
 
     fn transform_callable(&mut self, func: &lume_tir::Function) {
-        let id = lume_mir::FunctionId(func.id.as_usize());
+        let id = func.id;
         let func = FunctionTransformer::transform(self, id, func);
 
         self.mir.functions.insert(id, func);
@@ -62,7 +62,7 @@ pub(crate) struct FunctionTransformer<'mir> {
 
 impl<'mir> FunctionTransformer<'mir> {
     /// Defines the MIR function which is being created.
-    pub fn define(transformer: &'mir ModuleTransformer, id: FunctionId, func: &lume_tir::Function) -> Function {
+    pub fn define(transformer: &'mir ModuleTransformer, id: DefId, func: &lume_tir::Function) -> Function {
         let mut transformer = Self {
             transformer,
             func: Function::new(id, func.name_as_str(), func.location),
@@ -75,7 +75,7 @@ impl<'mir> FunctionTransformer<'mir> {
     }
 
     /// Transforms the supplied context into a MIR map.
-    pub fn transform(transformer: &'mir ModuleTransformer, id: FunctionId, func: &lume_tir::Function) -> Function {
+    pub fn transform(transformer: &'mir ModuleTransformer, id: DefId, func: &lume_tir::Function) -> Function {
         let mut transformer = Self {
             transformer,
             func: Function::new(id, func.name_as_str(), func.location),
@@ -143,7 +143,7 @@ impl<'mir> FunctionTransformer<'mir> {
         self.transformer.tcx
     }
 
-    pub(crate) fn function(&self, func_id: FunctionId) -> &Function {
+    pub(crate) fn function(&self, func_id: DefId) -> &Function {
         self.transformer.mir.function(func_id)
     }
 
@@ -184,7 +184,7 @@ impl<'mir> FunctionTransformer<'mir> {
     /// Defines a new call instruction in the current function block.
     fn call(
         &mut self,
-        func_id: FunctionId,
+        func_id: DefId,
         mut args: Vec<lume_mir::Operand>,
         ret_ty: lume_mir::Type,
         location: Location,

--- a/compiler/lume_mir_lower/src/ty.rs
+++ b/compiler/lume_mir_lower/src/ty.rs
@@ -1,3 +1,5 @@
+use lume_span::DefId;
+
 use crate::FunctionTransformer;
 
 impl FunctionTransformer<'_> {
@@ -109,7 +111,7 @@ impl FunctionTransformer<'_> {
         }
     }
 
-    pub(super) fn type_of_function(&self, func_id: lume_mir::FunctionId) -> lume_mir::Type {
+    pub(super) fn type_of_function(&self, func_id: DefId) -> lume_mir::Type {
         let func = self.function(func_id);
 
         func.signature.return_type.clone()

--- a/compiler/lume_span/src/id.rs
+++ b/compiler/lume_span/src/id.rs
@@ -364,3 +364,20 @@ pub enum DefId {
     Statement(StatementId),
     Expression(ExpressionId),
 }
+
+impl DefId {
+    pub fn as_usize(self) -> usize {
+        // Used to prevent `hash_id` from creating a value of 0 when the kind is
+        // `FunctionKind::Function` and the ID is 0. A function ID of 0 can look
+        // wrong or misleading, so we're explicitly removing that possiblity.
+        static HASH_OFFSET: usize = 0x4D6B_0189;
+
+        crate::hash_id(&(self, HASH_OFFSET))
+    }
+}
+
+impl std::fmt::Display for DefId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "F{:?}", self.as_usize())
+    }
+}

--- a/compiler/lume_tir/src/lib.rs
+++ b/compiler/lume_tir/src/lib.rs
@@ -1,12 +1,13 @@
 use indexmap::IndexMap;
+use lume_span::DefId;
 use lume_span::{ExpressionId, Interned, Location, StatementId};
-use lume_type_metadata::{FunctionId, StaticMetadata, TypeMetadataId};
+use lume_type_metadata::{StaticMetadata, TypeMetadataId};
 use lume_types::{Field, TypeRef};
 
 #[derive(Debug, Default)]
 pub struct TypedIR {
     pub metadata: StaticMetadata,
-    pub functions: IndexMap<FunctionId, Function>,
+    pub functions: IndexMap<DefId, Function>,
 }
 
 #[derive(Debug, Clone, Eq)]
@@ -156,7 +157,7 @@ pub struct VariableId(pub usize);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
-    pub id: FunctionId,
+    pub id: DefId,
     pub name: Path,
     pub parameters: Vec<Parameter>,
     pub type_params: TypeParameters,
@@ -458,7 +459,7 @@ pub struct ConstructorField {
 #[derive(Hash, Debug, Clone, PartialEq)]
 pub struct Call {
     pub id: ExpressionId,
-    pub function: FunctionId,
+    pub function: DefId,
     pub arguments: Vec<Expression>,
     pub type_arguments: Vec<TypeRef>,
     pub return_type: TypeRef,

--- a/compiler/lume_tir_lower/src/expr.rs
+++ b/compiler/lume_tir_lower/src/expr.rs
@@ -1,7 +1,6 @@
 use error_snippet::Result;
 use lume_span::{DefId, Internable};
 use lume_tir::VariableId;
-use lume_type_metadata::{FunctionId, FunctionKind};
 
 use crate::LowerFunction;
 
@@ -146,15 +145,8 @@ impl LowerFunction<'_> {
         );
 
         let function = match callable {
-            lume_typech::query::Callable::Function(call) => {
-                #[cfg(debug_assertions)]
-                if !call.sig().is_vararg() {
-                    debug_assert!(call.parameters.len() == expr.arguments().len());
-                }
-
-                FunctionId::new(FunctionKind::Function, call.id.index.as_usize())
-            }
-            lume_typech::query::Callable::Method(call) => FunctionId::new(FunctionKind::Method, call.id.0),
+            lume_typech::query::Callable::Function(call) => DefId::Item(call.hir),
+            lume_typech::query::Callable::Method(call) => call.hir,
         };
 
         let mut arguments = Vec::with_capacity(expr.arguments().len());

--- a/compiler/lume_tir_lower/src/reify/metadata.rs
+++ b/compiler/lume_tir_lower/src/reify/metadata.rs
@@ -157,7 +157,7 @@ impl ReificationPass<'_> {
 
         for method in self.tcx.methods_defined_on(type_ref) {
             let full_name = format!("{:+}", method.name);
-            let func_id = FunctionId::new(FunctionKind::Method, method.id.0);
+            let func_id = method.hir;
 
             let parameters = method
                 .parameters

--- a/compiler/lume_tir_lower/src/reify/metadata.rs
+++ b/compiler/lume_tir_lower/src/reify/metadata.rs
@@ -2,7 +2,7 @@ use lume_errors::Result;
 use lume_span::{DefId, hash_id};
 use lume_type_metadata::*;
 
-use crate::reify::ReificationPass;
+use crate::{reify::ReificationPass, should_skip_method};
 
 /// Defines the byte size of the current build architecture.
 const PTR_SIZE: usize = std::mem::size_of::<usize>();
@@ -156,6 +156,10 @@ impl ReificationPass<'_> {
         let mut methods = Vec::new();
 
         for method in self.tcx.methods_defined_on(type_ref) {
+            if should_skip_method(method, self.tcx.hir_body_of_def(method.hir).is_some()) {
+                continue;
+            }
+
             let full_name = format!("{:+}", method.name);
             let func_id = method.hir;
 

--- a/compiler/lume_type_metadata/src/lib.rs
+++ b/compiler/lume_type_metadata/src/lib.rs
@@ -1,29 +1,6 @@
 use indexmap::IndexMap;
+use lume_span::DefId;
 use lume_types::TypeId;
-
-#[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum FunctionKind {
-    Function,
-    Method,
-}
-
-#[derive(Hash, Debug, Copy, Clone, PartialEq, Eq)]
-pub struct FunctionId(usize);
-
-impl FunctionId {
-    pub fn new(kind: FunctionKind, id: usize) -> Self {
-        // Used to prevent `hash_id` from creating a value of 0 when the kind is
-        // `FunctionKind::Function` and the ID is 0. A function ID of 0 can look
-        // wrong or misleading, so we're explicitly removing that possiblity.
-        static HASH_OFFSET: usize = 0x4D6B_0189;
-
-        Self(lume_span::hash_id(&(kind, id + HASH_OFFSET)))
-    }
-
-    pub fn as_usize(self) -> usize {
-        self.0
-    }
-}
 
 #[derive(Default, Debug, Clone)]
 pub struct StaticMetadata {
@@ -104,7 +81,7 @@ pub struct MethodMetadata {
     pub full_name: String,
 
     /// Gets the unique ID of the method, used mostly for internal referencing.
-    pub func_id: FunctionId,
+    pub func_id: DefId,
 
     /// Gets all the parameters defined on the method, in the order that they're declared.
     pub parameters: Vec<ParameterMetadata>,

--- a/rt/src/metadata.rs
+++ b/rt/src/metadata.rs
@@ -3,7 +3,7 @@
 //! None of these structs are meant to be exported - they exist purely to
 //! better read type information from passed metadata arguments.
 
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -67,6 +67,9 @@ pub struct MethodMetadata {
 
     /// Gets the return type of the method.
     pub return_type: *const TypeMetadata,
+
+    /// Gets the address of the method.
+    pub func_ptr: *const c_void,
 }
 
 #[repr(C)]


### PR DESCRIPTION
Initial, and maybe naive, implementation of dynamic dispatch in Lume. Currently, code like the following will simply not compile:
```lm
import std::io (ToString)

fn foo<T: ToString>(val: T) {
    let str = val.to_string();
}
```


The reason is because the implementation of `to_string` depends entirely on the type of `T`, which can only be known at runtime. There might be optimizations we can implement later on, but a functional implementation is of higher priority.

The initial implementation will attempt to insert a shim which will lookup the correct method on the passed type parameter metadata and invoke it indirectly. This shim will be inserted when lowering into MIR. After the shim is created, the original call will be implicitly replaced with the location of the shim.

The idea is to make the shim function like the following (pseudocode):
```
fn _dyn_std::io::ToString::to_string(self, $T: TypeMetadata) -> String {
    for method in $T.methods {
        if method.id == /* Unique ID of std::io::ToString::to_string */ {
            let ptr = method.func_ptr;
            return ptr(self);
        }
    }

    // unreachable
}
```