### PR TITLE
feat: build dependency metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,8 +1117,6 @@ dependencies = [
  "lume_session",
  "lume_span",
  "lume_type_metadata",
- "lume_typech",
- "lume_types",
  "target-lexicon",
  "tracing",
 ]
@@ -1264,7 +1262,6 @@ dependencies = [
  "lume_errors",
  "lume_span",
  "lume_type_metadata",
- "lume_types",
  "tracing",
 ]
 

--- a/compiler/lume_codegen/Cargo.toml
+++ b/compiler/lume_codegen/Cargo.toml
@@ -14,8 +14,6 @@ lume_mir = { path = "../lume_mir" }
 lume_session = { path = "../lume_session" }
 lume_span = { path = "../lume_span" }
 lume_type_metadata = { path = "../lume_type_metadata" }
-lume_typech = { path = "../lume_typech" }
-lume_types = { path = "../lume_types" }
 
 error_snippet = { workspace = true }
 error_snippet_derive = { workspace = true }

--- a/compiler/lume_codegen/src/lib.rs
+++ b/compiler/lume_codegen/src/lib.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use lume_errors::Result;
 use lume_mir::ModuleMap;
 use lume_session::{Options, Package};
-use lume_typech::TyCheckCtx;
 
 #[cfg(feature = "codegen_cranelift")]
 mod cranelift;
@@ -38,18 +37,8 @@ pub struct CodegenObject {
 ///
 /// Returns `Err` if the selected backend returned an error while generating object files.
 #[tracing::instrument(level = "DEBUG", skip_all, fields(package = %package.path.display()), err)]
-pub fn generate<'ctx>(
-    package: &'ctx Package,
-    mir: ModuleMap,
-    tcx: &'ctx TyCheckCtx,
-    options: &'ctx Options,
-) -> Result<CompiledModule> {
-    let context = Context {
-        package,
-        mir,
-        tcx,
-        options,
-    };
+pub fn generate<'ctx>(package: &'ctx Package, mir: ModuleMap, options: &'ctx Options) -> Result<CompiledModule> {
+    let context = Context { package, mir, options };
 
     let mut backend: Box<dyn Backend<'_>> = match context.options.backend {
         #[cfg(feature = "codegen_cranelift")]
@@ -73,7 +62,6 @@ pub(crate) struct Context<'ctx> {
     pub package: &'ctx Package,
     pub mir: lume_mir::ModuleMap,
     pub options: &'ctx Options,
-    pub tcx: &'ctx TyCheckCtx,
 }
 
 pub(crate) trait Backend<'ctx> {

--- a/compiler/lume_driver/src/lib.rs
+++ b/compiler/lume_driver/src/lib.rs
@@ -263,8 +263,7 @@ impl<'a> Compiler<'a> {
             lume_session::MirPrinting::Debug => println!("{mir:#?}"),
         }
 
-        tracing::info_span!("codegen")
-            .in_scope(|| lume_codegen::generate(self.package, mir, tcx, &self.gcx.session.options))
+        tracing::info_span!("codegen").in_scope(|| lume_codegen::generate(self.package, mir, &self.gcx.session.options))
     }
 }
 

--- a/compiler/lume_hir/src/map.rs
+++ b/compiler/lume_hir/src/map.rs
@@ -5,7 +5,7 @@ use indexmap::{IndexMap, IndexSet};
 use lume_errors::Result;
 
 use crate::*;
-use lume_span::{ExpressionId, ItemId, PatternId, StatementId};
+use lume_span::{DefId, ExpressionId, StatementId};
 
 #[derive(Default, Clone, PartialEq)]
 pub struct Map {
@@ -13,16 +13,13 @@ pub struct Map {
     pub package: PackageId,
 
     /// Defines all the items within the module.
-    pub items: IndexMap<ItemId, Item>,
+    pub items: IndexMap<DefId, Def>,
 
     /// Defines all the local statements within the current scope.
     pub statements: IndexMap<StatementId, Statement>,
 
     /// Defines all the local expressions within the current scope.
     pub expressions: IndexMap<ExpressionId, Expression>,
-
-    /// Defines all the local patterns within the current scope.
-    pub patterns: IndexMap<PatternId, Pattern>,
 
     /// Defines all the imported paths within the HIR map.
     pub imports: IndexSet<Path>,
@@ -36,13 +33,12 @@ impl Map {
             items: IndexMap::new(),
             statements: IndexMap::new(),
             expressions: IndexMap::new(),
-            patterns: IndexMap::new(),
             imports: IndexSet::new(),
         }
     }
 
     /// Gets all the items within the HIR map.
-    pub fn items(&self) -> &IndexMap<ItemId, Item> {
+    pub fn items(&self) -> &IndexMap<DefId, Def> {
         &self.items
     }
 

--- a/compiler/lume_hir/src/pretty.rs
+++ b/compiler/lume_hir/src/pretty.rs
@@ -80,6 +80,21 @@ impl PrettyPrint for Item {
     }
 }
 
+impl PrettyPrint for Def {
+    fn pretty_fmt(&self, map: &Map, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Def::Item(def) => def.pretty_fmt(map, f),
+            Def::Method(def) => def.pretty_fmt(map, f),
+            Def::TraitMethodDef(def) => def.pretty_fmt(map, f),
+            Def::TraitMethodImpl(def) => def.pretty_fmt(map, f),
+            Def::Pattern(def) => def.pretty_fmt(map, f),
+            Def::Statement(def) => def.pretty_fmt(map, f),
+            Def::Expression(def) => def.pretty_fmt(map, f),
+            Def::Field(def) => def.pretty_fmt(map, f),
+        }
+    }
+}
+
 impl PrettyPrint for FunctionDefinition {
     fn pretty_fmt(&self, map: &Map, f: &mut Formatter<'_>) -> std::fmt::Result {
         let parameters = pretty_list!(self.parameters, map);

--- a/compiler/lume_hir_lower/src/generic.rs
+++ b/compiler/lume_hir_lower/src/generic.rs
@@ -9,7 +9,7 @@ use lume_hir::{self as hir};
 
 impl LowerModule<'_> {
     #[tracing::instrument(level = "DEBUG", skip_all, err)]
-    pub(crate) fn type_parameters(&self, params: Vec<ast::TypeParameter>) -> Result<hir::TypeParameters> {
+    pub(crate) fn type_parameters(&mut self, params: Vec<ast::TypeParameter>) -> Result<hir::TypeParameters> {
         let mut names: HashSet<lume_hir::Identifier> = HashSet::with_capacity(params.len());
         let mut type_params = Vec::with_capacity(params.len());
 

--- a/compiler/lume_hir_lower/src/pattern.rs
+++ b/compiler/lume_hir_lower/src/pattern.rs
@@ -5,7 +5,7 @@ use error_snippet::Result;
 impl LowerModule<'_> {
     #[tracing::instrument(level = "DEBUG", skip_all, err)]
     pub(super) fn pattern(&mut self, pattern: lume_ast::Pattern) -> Result<lume_hir::Pattern> {
-        let id = self.next_pat_id();
+        let id = self.next_def_id();
 
         let pat = match pattern {
             lume_ast::Pattern::Literal(pat) => {
@@ -63,7 +63,7 @@ impl LowerModule<'_> {
             }
         };
 
-        self.map.patterns.insert(id, pat.clone());
+        self.map.items.insert(id, lume_hir::Def::Pattern(pat.clone()));
 
         Ok(pat)
     }
@@ -75,7 +75,7 @@ impl LowerModule<'_> {
                 self.pattern(pattern)
             }
             lume_ast::Pattern::Identifier(pat) => {
-                let id = self.next_pat_id();
+                let id = self.next_def_id();
                 let name = self.identifier(pat);
                 let location = name.location;
 

--- a/compiler/lume_infer/src/lib.rs
+++ b/compiler/lume_infer/src/lib.rs
@@ -508,6 +508,58 @@ impl TyInferCtx {
 
         self.find_type_ref(&name).unwrap().unwrap()
     }
+
+    /// Creates a new [`TypeRef`] which refers to the type of the given name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type is not found within the database.
+    pub fn std_type_ref(&self, name: &str) -> TypeRef {
+        let name = lume_hir::Path::from_parts(
+            Some([lume_hir::PathSegment::namespace("std")]),
+            lume_hir::PathSegment::ty(name),
+        );
+
+        self.find_type_ref(&name).unwrap().unwrap()
+    }
+
+    /// Creates a new [`TypeRef`] which refers to the `std::String`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type is not found within the database.
+    pub fn std_ref_string(&self) -> TypeRef {
+        self.std_type_ref("String")
+    }
+
+    /// Creates a new [`TypeRef`] which refers to the `std::Array`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type is not found within the database.
+    pub fn std_ref_array(&self, elemental: TypeRef) -> TypeRef {
+        let mut ty = self.std_type_ref("Array");
+        ty.type_arguments.push(elemental);
+
+        ty
+    }
+
+    /// Creates a new [`TypeRef`] which refers to the `std::Pointer`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the type is not found within the database.
+    pub fn std_ref_pointer(&self, elemental: TypeRef) -> TypeRef {
+        let mut ty = self.std_type_ref("Pointer");
+        ty.type_arguments.push(elemental);
+
+        ty
+    }
+
+    /// Determines whether the given type is of type `std::Array`.
+    pub fn is_std_array(&self, ty: &TypeRef) -> bool {
+        ty.instance_of == self.std_type_ref("Array").instance_of
+    }
 }
 
 impl Deref for TyInferCtx {

--- a/compiler/lume_infer/src/query/mod.rs
+++ b/compiler/lume_infer/src/query/mod.rs
@@ -211,7 +211,7 @@ impl TyInferCtx {
                 lume_hir::FloatKind::F32 => TypeRef::f32(),
                 lume_hir::FloatKind::F64 => TypeRef::f64(),
             },
-            lume_hir::LiteralKind::String(_) => TypeRef::string(),
+            lume_hir::LiteralKind::String(_) => self.std_ref_string(),
             lume_hir::LiteralKind::Boolean(_) => TypeRef::bool(),
         };
 
@@ -222,28 +222,11 @@ impl TyInferCtx {
     /// ancestry tree has been initialized.
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip(self), err)]
-    pub fn type_of_parameter_pre(
-        &self,
-        param: &lume_hir::Parameter,
-        type_params: &[&TypeParameter],
-    ) -> Result<TypeRef> {
+    pub fn type_of_parameter(&self, param: &lume_hir::Parameter, type_params: &[&TypeParameter]) -> Result<TypeRef> {
         let elemental_type = self.mk_type_ref_generic(&param.param_type, type_params)?;
 
         if param.vararg {
-            Result::Ok(TypeRef::array(elemental_type))
-        } else {
-            Result::Ok(elemental_type)
-        }
-    }
-
-    /// Returns the *type* of the given [`lume_hir::Parameter`].
-    #[cached_query(result)]
-    #[tracing::instrument(level = "TRACE", skip(self), err)]
-    pub fn type_of_parameter(&self, param: &lume_hir::Parameter, owner: lume_span::ItemId) -> Result<TypeRef> {
-        let elemental_type = self.mk_type_ref_from(&param.param_type, lume_span::DefId::Item(owner))?;
-
-        if param.vararg {
-            Result::Ok(TypeRef::array(elemental_type))
+            Result::Ok(self.std_ref_array(elemental_type))
         } else {
             Result::Ok(elemental_type)
         }

--- a/compiler/lume_mir/Cargo.toml
+++ b/compiler/lume_mir/Cargo.toml
@@ -13,7 +13,6 @@ doctest = false
 lume_errors = { path = "../lume_errors" }
 lume_span = { path = "../lume_span" }
 lume_type_metadata = { path = "../lume_type_metadata" }
-lume_types = { path = "../lume_types" }
 
 indexmap = { version = "^2.9" }
 tracing = { workspace = true }

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -1309,14 +1309,9 @@ impl std::fmt::Display for BlockBranchSite {
     }
 }
 
-pub type TypeId = lume_types::TypeId;
-
-pub type TypeRef = lume_types::TypeRef;
-
 /// Defines a type within the MIR.
 #[derive(Hash, Debug, Clone, PartialEq, Eq)]
 pub struct Type {
-    pub id: TypeRef,
     pub kind: TypeKind,
     pub is_generic: bool,
 }
@@ -1324,7 +1319,6 @@ pub struct Type {
 impl Type {
     pub fn void() -> Self {
         Self {
-            id: TypeRef::void(),
             kind: TypeKind::Void,
             is_generic: false,
         }
@@ -1332,7 +1326,6 @@ impl Type {
 
     pub fn boolean() -> Self {
         Self {
-            id: TypeRef::bool(),
             kind: TypeKind::Boolean,
             is_generic: false,
         }
@@ -1340,7 +1333,6 @@ impl Type {
 
     pub fn string() -> Self {
         Self {
-            id: TypeRef::string(),
             kind: TypeKind::String,
             is_generic: false,
         }
@@ -1348,7 +1340,6 @@ impl Type {
 
     pub fn pointer(elemental: Type) -> Self {
         Self {
-            id: TypeRef::pointer(elemental.id.clone()),
             kind: TypeKind::Pointer {
                 elemental: Box::new(elemental),
             },
@@ -1358,7 +1349,6 @@ impl Type {
 
     pub fn type_param() -> Self {
         Self {
-            id: TypeRef::pointer(TypeRef::void()),
             kind: TypeKind::Pointer {
                 elemental: Box::new(Type::void()),
             },
@@ -1382,7 +1372,6 @@ impl Type {
 
     pub fn i8() -> Self {
         Self {
-            id: TypeRef::i8(),
             kind: TypeKind::Integer { bits: 8, signed: true },
             is_generic: false,
         }
@@ -1390,7 +1379,6 @@ impl Type {
 
     pub fn u8() -> Self {
         Self {
-            id: TypeRef::u8(),
             kind: TypeKind::Integer { bits: 8, signed: false },
             is_generic: false,
         }
@@ -1398,7 +1386,6 @@ impl Type {
 
     pub fn i16() -> Self {
         Self {
-            id: TypeRef::i16(),
             kind: TypeKind::Integer { bits: 16, signed: true },
             is_generic: false,
         }
@@ -1406,7 +1393,6 @@ impl Type {
 
     pub fn u16() -> Self {
         Self {
-            id: TypeRef::u16(),
             kind: TypeKind::Integer {
                 bits: 16,
                 signed: false,
@@ -1417,7 +1403,6 @@ impl Type {
 
     pub fn i32() -> Self {
         Self {
-            id: TypeRef::i32(),
             kind: TypeKind::Integer { bits: 32, signed: true },
             is_generic: false,
         }
@@ -1425,7 +1410,6 @@ impl Type {
 
     pub fn u32() -> Self {
         Self {
-            id: TypeRef::u32(),
             kind: TypeKind::Integer {
                 bits: 32,
                 signed: false,
@@ -1436,7 +1420,6 @@ impl Type {
 
     pub fn i64() -> Self {
         Self {
-            id: TypeRef::i64(),
             kind: TypeKind::Integer { bits: 64, signed: true },
             is_generic: false,
         }
@@ -1444,7 +1427,6 @@ impl Type {
 
     pub fn u64() -> Self {
         Self {
-            id: TypeRef::u64(),
             kind: TypeKind::Integer {
                 bits: 64,
                 signed: false,
@@ -1463,7 +1445,6 @@ impl Type {
 
     pub fn f32() -> Self {
         Self {
-            id: TypeRef::f32(),
             kind: TypeKind::Float { bits: 32 },
             is_generic: false,
         }
@@ -1471,31 +1452,27 @@ impl Type {
 
     pub fn f64() -> Self {
         Self {
-            id: TypeRef::f64(),
             kind: TypeKind::Float { bits: 64 },
             is_generic: false,
         }
     }
 
-    pub fn structure(id: TypeRef, name: String, fields: Vec<Type>) -> Self {
+    pub fn structure(name: String, fields: Vec<Type>) -> Self {
         Self {
-            id,
             kind: TypeKind::Struct { name, fields },
             is_generic: false,
         }
     }
 
-    pub fn union(id: TypeRef, cases: Vec<Type>) -> Self {
+    pub fn union(cases: Vec<Type>) -> Self {
         Self {
-            id,
             kind: TypeKind::Union { cases },
             is_generic: false,
         }
     }
 
-    pub fn tuple(id: TypeRef, items: Vec<Type>) -> Self {
+    pub fn tuple(items: Vec<Type>) -> Self {
         Self {
-            id,
             kind: TypeKind::Tuple { items },
             is_generic: false,
         }

--- a/compiler/lume_mir_lower/src/dynamic/mod.rs
+++ b/compiler/lume_mir_lower/src/dynamic/mod.rs
@@ -406,16 +406,7 @@ impl<'shim, 'mir, 'tcx> DynamicShimBuilder<'shim, 'mir, 'tcx> {
     }
 
     fn method_metadata_type(&self) -> lume_mir::Type {
-        let method_type_name = lume_hir::Path::from_parts(
-            Some([lume_hir::PathSegment::namespace("std")]),
-            lume_hir::PathSegment::ty("Method"),
-        );
-
-        let id = self.builder.tcx().db().find_type(&method_type_name).unwrap().id;
-        let type_ref = lume_types::TypeRef::new(id, Location::empty());
-
         lume_mir::Type::pointer(lume_mir::Type::structure(
-            type_ref,
             String::from("std::Method"),
             vec![
                 lume_mir::Type::pointer(lume_mir::Type::void()), // full_name,

--- a/compiler/lume_mir_lower/src/expr.rs
+++ b/compiler/lume_mir_lower/src/expr.rs
@@ -148,7 +148,7 @@ impl FunctionTransformer<'_, '_> {
 
         let prop_sizes = prop_types.iter().map(lume_mir::Type::bytesize).collect::<Vec<_>>();
 
-        let struct_type = lume_mir::Type::structure(expr.ty.clone(), name, prop_types);
+        let struct_type = lume_mir::Type::structure(name, prop_types);
         let struct_ptr = lume_mir::Type::pointer(struct_type.clone());
 
         let reg = self.func.add_register(struct_ptr);
@@ -827,10 +827,10 @@ impl FunctionTransformer<'_, '_> {
                 items.push(self.lower_type(&case_ref));
             }
 
-            union_cases.push(lume_mir::Type::tuple(enum_ty.clone(), items));
+            union_cases.push(lume_mir::Type::tuple(items));
         }
 
-        let union_type = lume_mir::Type::union(expr.ty.clone(), union_cases);
+        let union_type = lume_mir::Type::union(union_cases);
         let reg = self.func.add_register(union_type.clone());
         self.func.current_block_mut().allocate(reg, union_type, expr.location);
 

--- a/compiler/lume_mir_lower/src/ty.rs
+++ b/compiler/lume_mir_lower/src/ty.rs
@@ -18,12 +18,12 @@ impl FunctionTransformer<'_, '_> {
                 let ty_props = self.tcx().db().find_fields(type_ref.instance_of);
                 let props = ty_props.map(|p| self.lower_type(&p.field_type)).collect::<Vec<_>>();
 
-                let struct_ty = lume_mir::Type::structure(type_ref.clone(), name, props);
+                let struct_ty = lume_mir::Type::structure(name, props);
 
                 lume_mir::Type::pointer(struct_ty)
             }
             lume_types::TypeKind::User(lume_types::UserType::Enum(_)) => {
-                let enum_ty = lume_mir::Type::union(type_ref.clone(), Vec::new());
+                let enum_ty = lume_mir::Type::union(Vec::new());
 
                 lume_mir::Type::pointer(enum_ty)
             }
@@ -116,17 +116,12 @@ impl FunctionTransformer<'_, '_> {
                 | lume_mir::Intrinsic::FloatSub { bits }
                 | lume_mir::Intrinsic::FloatMul { bits }
                 | lume_mir::Intrinsic::FloatDiv { bits } => lume_mir::Type::float(*bits),
-                lume_mir::Intrinsic::Metadata { metadata } => {
-                    let id = self.tcx().std_type();
-
-                    lume_mir::Type {
-                        id,
-                        kind: lume_mir::TypeKind::Metadata {
-                            inner: metadata.clone(),
-                        },
-                        is_generic: false,
-                    }
-                }
+                lume_mir::Intrinsic::Metadata { metadata } => lume_mir::Type {
+                    kind: lume_mir::TypeKind::Metadata {
+                        inner: metadata.clone(),
+                    },
+                    is_generic: false,
+                },
             },
             lume_mir::DeclarationKind::Cast { operand, bits } => {
                 let operand_ty = self.func.registers.register_ty(*operand);

--- a/compiler/lume_tir_lower/src/reify/metadata.rs
+++ b/compiler/lume_tir_lower/src/reify/metadata.rs
@@ -120,7 +120,7 @@ impl ReificationPass<'_> {
             }
             lume_types::TypeKind::User(lume_types::UserType::Struct(_)) => {
                 // Arrays are aligned to their elemental type alignment
-                if type_ref.instance_of == lume_types::TYPEREF_ARRAY_ID {
+                if self.tcx.is_std_array(type_ref) {
                     return self.alignment_of_ty(type_ref.type_arguments.first().unwrap());
                 }
 

--- a/compiler/lume_tir_lower/src/reify/mod.rs
+++ b/compiler/lume_tir_lower/src/reify/mod.rs
@@ -146,6 +146,7 @@ impl<'tcx> ReificationPass<'tcx> {
 
     fn add_metadata_argument_concrete(&mut self, type_arg: &TypeRef) -> Result<lume_tir::Expression> {
         let id = self.build_type_metadata_of(type_arg)?;
+        let ty = self.tcx.std_ref_pointer(self.tcx.std_type());
 
         Ok(lume_tir::Expression {
             kind: ExpressionKind::IntrinsicCall(Box::new(lume_tir::IntrinsicCall {
@@ -154,7 +155,7 @@ impl<'tcx> ReificationPass<'tcx> {
                 arguments: Vec::new(),
                 location: type_arg.location,
             })),
-            ty: TypeRef::pointer(self.tcx.std_type()),
+            ty,
         })
     }
 }

--- a/compiler/lume_types/src/errors.rs
+++ b/compiler/lume_types/src/errors.rs
@@ -1,43 +1,13 @@
 use error_snippet_derive::Diagnostic;
-use lume_hir::{FieldId, FunctionId, ImplId, MethodId, Path, TypeId, UseId};
-use lume_span::Location;
+use lume_hir::Path;
+use lume_span::{DefId, Location};
 
 use crate::{Item, TypeKindRef};
 
 #[derive(Diagnostic, Debug)]
-#[diagnostic(message = "could not find function {id:?} in context")]
-pub struct FunctionNotFound {
-    pub id: FunctionId,
-}
-
-#[derive(Diagnostic, Debug)]
-#[diagnostic(message = "could not find field {id:?} in context")]
-pub struct FieldNotFound {
-    pub id: FieldId,
-}
-
-#[derive(Diagnostic, Debug)]
-#[diagnostic(message = "could not find method {id:?} in context")]
-pub struct MethodNotFound {
-    pub id: MethodId,
-}
-
-#[derive(Diagnostic, Debug)]
-#[diagnostic(message = "could not find implementation {id:?} in context")]
-pub struct ImplNotFound {
-    pub id: ImplId,
-}
-
-#[derive(Diagnostic, Debug)]
-#[diagnostic(message = "could not find trait implementation {id:?} in context")]
-pub struct UseNotFound {
-    pub id: UseId,
-}
-
-#[derive(Diagnostic, Debug)]
-#[diagnostic(message = "could not find item {id:?} in context")]
-pub struct TypeNotFound {
-    pub id: TypeId,
+#[diagnostic(message = "could not find definition {id:?} in context")]
+pub struct DefNotFound {
+    pub id: DefId,
 }
 
 #[derive(Diagnostic, Debug)]

--- a/compiler/lume_types/src/lib.rs
+++ b/compiler/lume_types/src/lib.rs
@@ -134,9 +134,6 @@ pub const TYPEREF_UINT32_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_000
 pub const TYPEREF_UINT64_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_00009);
 pub const TYPEREF_FLOAT32_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_0000A);
 pub const TYPEREF_FLOAT64_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_0000B);
-pub const TYPEREF_STRING_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_0000C);
-pub const TYPEREF_POINTER_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_0000D);
-pub const TYPEREF_ARRAY_ID: TypeId = TypeId::new(PackageId::empty(), 0x0000_0000E);
 pub const TYPEREF_UNKNOWN_ID: TypeId = TypeId::new(PackageId::empty(), 0xFFFF_FFFF);
 
 #[derive(Debug, Clone, PartialEq)]
@@ -674,41 +671,6 @@ impl Type {
         }
     }
 
-    /// Creates a new [`Type`] with an inner type of [`TypeKind::String`].
-    pub fn string() -> Self {
-        Self {
-            id: TYPEREF_STRING_ID,
-            kind: TypeKind::String,
-            name: Path::string(),
-        }
-    }
-
-    /// Creates a new [`Type`] with an inner type of [`TypeKind::Pointer`].
-    pub fn pointer() -> Self {
-        Self {
-            id: TYPEREF_POINTER_ID,
-            kind: TypeKind::User(UserType::Struct(Box::new(Struct {
-                id: ItemId::from_name(PackageId::empty(), &Path::pointer()),
-                name: Path::pointer(),
-                type_parameters: vec![TypeParameterId(0)],
-            }))),
-            name: Path::pointer(),
-        }
-    }
-
-    /// Creates a new [`Type`] with an inner type of [`TypeKind::Pointer`].
-    pub fn array() -> Self {
-        Self {
-            id: TYPEREF_ARRAY_ID,
-            kind: TypeKind::User(UserType::Struct(Box::new(Struct {
-                id: ItemId::from_name(PackageId::empty(), &Path::array()),
-                name: Path::array(),
-                type_parameters: vec![TypeParameterId(1)],
-            }))),
-            name: Path::array(),
-        }
-    }
-
     pub fn is_type_parameter(&self) -> bool {
         matches!(self.kind, TypeKind::TypeParameter(_))
     }
@@ -851,33 +813,6 @@ impl TypeRef {
         }
     }
 
-    /// Creates a new [`Type`] with an inner type of [`TypeKind::String`].
-    pub fn string() -> Self {
-        Self {
-            instance_of: TYPEREF_STRING_ID,
-            type_arguments: vec![],
-            location: Location::empty(),
-        }
-    }
-
-    /// Creates a new [`Type`] with an inner type of [`TypeKind::Pointer`].
-    pub fn pointer(elemental: TypeRef) -> Self {
-        Self {
-            instance_of: TYPEREF_POINTER_ID,
-            type_arguments: vec![elemental],
-            location: Location::empty(),
-        }
-    }
-
-    /// Creates a new [`Type`] with an inner type of [`TypeKind::Pointer`].
-    pub fn array(elemental: TypeRef) -> Self {
-        Self {
-            instance_of: TYPEREF_ARRAY_ID,
-            type_arguments: vec![elemental],
-            location: Location::empty(),
-        }
-    }
-
     /// Creates a new [`TypeRef`] with an invalid inner type, meant to
     /// be used before any types are actually resolved.
     pub fn unknown() -> Self {
@@ -994,21 +929,6 @@ impl TypeRef {
     /// Determines if the type is an `f64`.
     pub fn is_f64(&self) -> bool {
         self.instance_of == TYPEREF_FLOAT64_ID
-    }
-
-    /// Determines if the type is an `string`.
-    pub fn is_string(&self) -> bool {
-        self.instance_of == TYPEREF_STRING_ID
-    }
-
-    /// Determines if the type is an `array`.
-    pub fn is_array(&self) -> bool {
-        self.instance_of == TYPEREF_ARRAY_ID
-    }
-
-    /// Determines if the type is a `pointer`.
-    pub fn is_pointer(&self) -> bool {
-        self.instance_of == TYPEREF_POINTER_ID
     }
 
     /// Determines if the type is unknown.
@@ -1613,27 +1533,11 @@ impl Default for TypeDatabaseContext {
                 TYPEREF_UINT64_ID => Type::u64(),
                 TYPEREF_FLOAT32_ID => Type::f32(),
                 TYPEREF_FLOAT64_ID => Type::f64(),
-                TYPEREF_STRING_ID => Type::string(),
-                TYPEREF_POINTER_ID => Type::pointer(),
-                TYPEREF_ARRAY_ID => Type::array(),
             },
             fields: Vec::new(),
             methods: Vec::new(),
             functions: IndexMap::new(),
-            type_parameters: vec![
-                TypeParameter {
-                    id: TypeParameterId(0),
-                    name: String::from("T"),
-                    constraints: Vec::new(),
-                    location: Location::empty(),
-                },
-                TypeParameter {
-                    id: TypeParameterId(1),
-                    name: String::from("T"),
-                    constraints: Vec::new(),
-                    location: Location::empty(),
-                },
-            ],
+            type_parameters: Vec::new(),
             implementations: Vec::new(),
             uses: Vec::new(),
         }

--- a/tools/build_stage/src/lib.rs
+++ b/tools/build_stage/src/lib.rs
@@ -101,7 +101,7 @@ impl ManifoldDriver {
         let (tcx, tir) = self.build_tir()?;
         let mir = lume_mir_lower::ModuleTransformer::transform(&tcx, tir);
 
-        let compiled_module = lume_codegen::generate(&self.package, mir, &tcx, &self.gcx.session.options)?;
+        let compiled_module = lume_codegen::generate(&self.package, mir, &self.gcx.session.options)?;
         let objects = lume_linker::write_object_files(
             &self.gcx,
             CodegenResult {


### PR DESCRIPTION
Attempts to build metadata for each dependency which has been type-checked and compiled. This will eventually allow for functional dependency resolution and type-checking across packages.

As part of the PR, some changes had to be made:
### **Many ID types will be merged into `DefId` and `ItemId`**
ID types like `MethodId`, `FieldId`, etc. had no package component, so we'd never be able to tell which package it originated from. Instead of adding these components to each ID type, most have been merged into `DefId` and `ItemId`.

While it's possible to have made each ID type have its own `package` field, it would add additional clutter. It would also make each ID effectively function the same as a `DefId`, making the entire approach of having multiple IDs for a single item pointless.