### PR TITLE
style(mir): simplify MIR dump output

### DIFF
--- a/compiler/lume_cli/src/lib.rs
+++ b/compiler/lume_cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::struct_excessive_bools)]
+
 pub(crate) mod commands;
 pub(crate) mod error;
 pub(crate) mod opts;

--- a/compiler/lume_cli/src/opts.rs
+++ b/compiler/lume_cli/src/opts.rs
@@ -112,6 +112,13 @@ pub struct DevelopmentBuildOptions {
     #[cfg_attr(not(debug_assertions), arg(hide = true))]
     pub dump_mir_func: Vec<String>,
 
+    /// Dumps all MIR instructions.
+    ///
+    /// Forces MIR dumps to include GC references, untagging, etc.
+    #[arg(long)]
+    #[cfg_attr(not(debug_assertions), arg(hide = true))]
+    pub dump_mir_full: bool,
+
     /// Dumps the generated codegen IR
     #[arg(long)]
     #[cfg_attr(not(debug_assertions), arg(hide = true))]
@@ -149,6 +156,7 @@ impl BuildOptions {
             dump_hir: self.dev.dump_hir,
             dump_mir: self.dev.dump_mir.clone(),
             dump_mir_func: self.dev.dump_mir_func.clone(),
+            dump_mir_full: self.dev.dump_mir_full,
             dump_codegen_ir: self.dev.dump_codegen_ir,
         }
     }

--- a/compiler/lume_codegen/src/value.rs
+++ b/compiler/lume_codegen/src/value.rs
@@ -107,13 +107,6 @@ impl LowerFunction<'_> {
                         .load(self.backend.cl_ptr_type(), MemFlags::trusted(), value, 0)
                 }
             },
-            lume_mir::DeclarationKind::Untagged { operand } => {
-                let value = self.cg_operand(operand);
-
-                self.builder
-                    .ins()
-                    .band_imm(value, !lume_tagged::TAG_MASK.cast_signed() as i64)
-            }
         }
     }
 
@@ -182,6 +175,13 @@ impl LowerFunction<'_> {
                 self.builder.ins().stack_addr(self.backend.cl_ptr_type(), slot, offset)
             }
             lume_mir::OperandKind::Reference { id } => self.use_var(*id),
+            lume_mir::OperandKind::Untagged { id } => {
+                let value = self.use_var(*id);
+
+                self.builder
+                    .ins()
+                    .band_imm(value, !lume_tagged::TAG_MASK.cast_signed() as i64)
+            }
         }
     }
 }

--- a/compiler/lume_mir/src/fmt.rs
+++ b/compiler/lume_mir/src/fmt.rs
@@ -1,0 +1,21 @@
+pub struct WithFlags<'a, T> {
+    pub value: &'a T,
+    pub alternate: bool,
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for WithFlags<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.alternate {
+            write!(f, "{:#}", self.value)
+        } else {
+            write!(f, "{}", self.value)
+        }
+    }
+}
+
+pub(crate) fn with_flags<'a, T: std::fmt::Display>(f: &std::fmt::Formatter<'_>, value: &'a T) -> WithFlags<'a, T> {
+    WithFlags {
+        value,
+        alternate: f.alternate(),
+    }
+}

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -1,7 +1,10 @@
+pub mod fmt;
+
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::hash::Hash;
 
+pub use fmt::*;
 use indexmap::{IndexMap, IndexSet};
 use lume_session::{Options, Package};
 use lume_span::{Interned, Location, NodeId, SourceFile};
@@ -94,14 +97,8 @@ impl ModuleMap {
 
 impl std::fmt::Display for ModuleMap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if f.alternate() {
-            for func in self.functions.values() {
-                write!(f, "{func:#}")?;
-            }
-        } else {
-            for func in self.functions.values() {
-                write!(f, "{func}")?;
-            }
+        for func in self.functions.values() {
+            write!(f, "{}", with_flags(f, func))?;
         }
 
         Ok(())
@@ -148,7 +145,12 @@ impl std::fmt::Display for Signature {
                 .map(|(idx, param)| {
                     let is_last = idx == self.parameters.len() - 1;
 
-                    format!("{}{param} #{idx}", if is_last && self.vararg { "..." } else { "" })
+                    format!(
+                        "{}{} {}",
+                        if is_last && self.vararg { "..." } else { "" },
+                        with_flags(f, param),
+                        RegisterId::new(idx)
+                    )
                 })
                 .collect::<Vec<String>>()
                 .join(", "),
@@ -169,7 +171,7 @@ pub struct Parameter {
 
 impl std::fmt::Display for Parameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{}: {}", self.name, self.ty))
+        f.write_fmt(format_args!("{}: {}", self.name, with_flags(f, &self.ty)))
     }
 }
 
@@ -455,20 +457,14 @@ impl Function {
 impl std::fmt::Display for Function {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.signature.external {
-            writeln!(f, "extern fn {:?} {}", self.name, self.signature)?;
+            writeln!(f, "extern fn {:?} {}", self.name, with_flags(f, &self.signature))?;
             return writeln!(f);
         }
 
-        writeln!(f, "fn {:?} {} {{", self.name, self.signature)?;
+        writeln!(f, "fn {:?} {} {{", self.name, with_flags(f, &self.signature))?;
 
-        if f.alternate() {
-            for block in self.blocks.values() {
-                write!(f, "{block:#}")?;
-            }
-        } else {
-            for block in self.blocks.values() {
-                write!(f, "{block}")?;
-            }
+        for block in self.blocks.values() {
+            write!(f, "{}", with_flags(f, block))?;
         }
 
         writeln!(f, "}}")?;
@@ -1029,11 +1025,11 @@ impl std::fmt::Display for BasicBlock {
                 continue;
             }
 
-            writeln!(f, "    {stmt}")?;
+            writeln!(f, "    {}", with_flags(f, stmt))?;
         }
 
         if let Some(terminator) = &self.terminator {
-            writeln!(f, "    {terminator}")?;
+            writeln!(f, "    {}", with_flags(f, terminator))?;
         }
 
         Ok(())
@@ -1269,7 +1265,9 @@ impl Instruction {
 impl std::fmt::Display for Instruction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
-            InstructionKind::Let { register, decl, ty } => write!(f, "let {register}: {ty} = {decl}"),
+            InstructionKind::Let { register, decl, ty } => {
+                write!(f, "let {register}: {} = {}", with_flags(f, ty), with_flags(f, decl))
+            }
             InstructionKind::CreateSlot { slot, ty } => write!(
                 f,
                 "{slot} = slot ({} bytes)",
@@ -1279,10 +1277,14 @@ impl std::fmt::Display for Instruction {
                     ty.bytesize()
                 }
             ),
-            InstructionKind::Allocate { register, ty, .. } => write!(f, "{register} = alloc {ty}"),
-            InstructionKind::Store { target, value } => write!(f, "*{target} = {value}"),
-            InstructionKind::StoreSlot { target, value, offset } => write!(f, "*{target}[+x{offset:X}] = {value}"),
-            InstructionKind::StoreField { target, offset, value } => write!(f, "*{target}[+x{offset:X}] = {value}"),
+            InstructionKind::Allocate { register, ty, .. } => write!(f, "{register} = alloc {}", with_flags(f, ty)),
+            InstructionKind::Store { target, value } => write!(f, "*{target} = {}", with_flags(f, value)),
+            InstructionKind::StoreSlot { target, value, offset } => {
+                write!(f, "*{target}[+x{offset:X}] = {}", with_flags(f, value))
+            }
+            InstructionKind::StoreField { target, offset, value } => {
+                write!(f, "*{target}[+x{offset:X}] = {}", with_flags(f, value))
+            }
             InstructionKind::ObjectRegister { register } => write!(f, "mark object({register})"),
         }
     }
@@ -1347,17 +1349,26 @@ impl std::fmt::Display for Declaration {
             DeclarationKind::Intrinsic { name, args } => write!(
                 f,
                 "{name}({})",
-                args.iter().map(|arg| format!("{arg}")).collect::<Vec<_>>().join(", ")
+                args.iter()
+                    .map(|arg| format!("{}", with_flags(f, arg)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
             DeclarationKind::Call { name, args, .. } => write!(
                 f,
                 "call {name}({})",
-                args.iter().map(|arg| format!("{arg}")).collect::<Vec<_>>().join(", ")
+                args.iter()
+                    .map(|arg| format!("{}", with_flags(f, arg)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
             DeclarationKind::IndirectCall { ptr, args, .. } => write!(
                 f,
                 "call indirect {ptr}({})",
-                args.iter().map(|arg| format!("{arg}")).collect::<Vec<_>>().join(", ")
+                args.iter()
+                    .map(|arg| format!("{}", with_flags(f, arg)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
         }
     }
@@ -1718,7 +1729,7 @@ impl std::fmt::Display for Terminator {
         match &self.kind {
             TerminatorKind::Return(value) => {
                 if let Some(value) = value {
-                    write!(f, "return {value}")
+                    write!(f, "return {}", with_flags(f, value))
                 } else {
                     write!(f, "return")
                 }
@@ -1775,7 +1786,7 @@ impl std::fmt::Display for BlockBranchSite {
                 "({})",
                 self.arguments
                     .iter()
-                    .map(|arg| format!("{arg}"))
+                    .map(|arg| format!("{}", with_flags(f, arg)))
                     .collect::<Vec<_>>()
                     .join(", ")
             )?;
@@ -2127,29 +2138,43 @@ impl std::fmt::Display for TypeKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             Self::Struct { name, .. } => write!(f, "{name}"),
-            Self::Union { cases } => write!(
-                f,
-                "(u8, {})",
-                cases
-                    .iter()
-                    .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-            Self::Tuple { items } => write!(
-                f,
-                "({})",
-                items
-                    .iter()
-                    .map(std::string::ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
+            Self::Union { cases } => {
+                write!(f, "(u8, ")?;
+
+                for (idx, item) in cases.iter().enumerate() {
+                    write!(f, "{}", with_flags(f, item))?;
+
+                    if idx < cases.len() - 1 {
+                        write!(f, ", ")?;
+                    }
+                }
+
+                write!(f, ")")
+            }
+            Self::Tuple { items } => {
+                write!(f, "(")?;
+
+                for (idx, item) in items.iter().enumerate() {
+                    write!(f, "{}", with_flags(f, item))?;
+
+                    if idx < items.len() - 1 {
+                        write!(f, ", ")?;
+                    }
+                }
+
+                write!(f, ")")
+            }
             Self::Integer { bits, signed } => write!(f, "{}{bits}", if *signed { "i" } else { "u" }),
             Self::Float { bits } => write!(f, "f{bits}"),
             Self::Boolean => write!(f, "bool"),
             Self::String => write!(f, "string"),
-            Self::Box { elemental } => write!(f, "box {elemental}"),
+            Self::Box { elemental } => {
+                if f.alternate() {
+                    write!(f, "box {elemental}")
+                } else {
+                    write!(f, "ptr {elemental}")
+                }
+            }
             Self::Pointer { elemental } => write!(f, "ptr {elemental}"),
             Self::Metadata { inner } => write!(f, "metadata {}", inner.full_name),
             Self::Void => write!(f, "void"),

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -94,8 +94,14 @@ impl ModuleMap {
 
 impl std::fmt::Display for ModuleMap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for func in self.functions.values() {
-            write!(f, "{func}")?;
+        if f.alternate() {
+            for func in self.functions.values() {
+                write!(f, "{func:#}")?;
+            }
+        } else {
+            for func in self.functions.values() {
+                write!(f, "{func}")?;
+            }
         }
 
         Ok(())
@@ -455,8 +461,14 @@ impl std::fmt::Display for Function {
 
         writeln!(f, "fn {:?} {} {{", self.name, self.signature)?;
 
-        for block in self.blocks.values() {
-            write!(f, "{block}")?;
+        if f.alternate() {
+            for block in self.blocks.values() {
+                write!(f, "{block:#}")?;
+            }
+        } else {
+            for block in self.blocks.values() {
+                write!(f, "{block}")?;
+            }
         }
 
         writeln!(f, "}}")?;
@@ -1013,6 +1025,10 @@ impl std::fmt::Display for BasicBlock {
         )?;
 
         for stmt in self.instructions() {
+            if !f.alternate() && stmt.is_auxiliary() {
+                continue;
+            }
+
             writeln!(f, "    {stmt}")?;
         }
 
@@ -1243,6 +1259,10 @@ impl Instruction {
             | InstructionKind::Allocate { .. }
             | InstructionKind::StoreSlot { .. } => Vec::new(),
         }
+    }
+
+    pub fn is_auxiliary(&self) -> bool {
+        matches!(&self.kind, InstructionKind::ObjectRegister { .. })
     }
 }
 

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -154,7 +154,7 @@ impl std::fmt::Display for Signature {
                 })
                 .collect::<Vec<String>>()
                 .join(", "),
-            self.return_type
+            with_flags(f, &self.return_type)
         )
     }
 }
@@ -1004,7 +1004,7 @@ impl std::fmt::Display for BasicBlock {
                 "({})",
                 self.parameters
                     .iter()
-                    .map(std::string::ToString::to_string)
+                    .map(|param| format!("{}", with_flags(f, param)))
                     .collect::<Vec<_>>()
                     .join(", ")
             )?;
@@ -1015,7 +1015,7 @@ impl std::fmt::Display for BasicBlock {
             ":  {}",
             self.predecessors
                 .iter()
-                .map(std::string::ToString::to_string)
+                .map(|id| format!("{}", with_flags(f, id)))
                 .collect::<Vec<_>>()
                 .join(", ")
         )?;
@@ -2170,12 +2170,12 @@ impl std::fmt::Display for TypeKind {
             Self::String => write!(f, "string"),
             Self::Box { elemental } => {
                 if f.alternate() {
-                    write!(f, "box {elemental}")
+                    write!(f, "box {}", with_flags(f, elemental))
                 } else {
-                    write!(f, "ptr {elemental}")
+                    write!(f, "ptr {}", with_flags(f, elemental))
                 }
             }
-            Self::Pointer { elemental } => write!(f, "ptr {elemental}"),
+            Self::Pointer { elemental } => write!(f, "ptr {}", with_flags(f, elemental)),
             Self::Metadata { inner } => write!(f, "metadata {}", inner.full_name),
             Self::Void => write!(f, "void"),
             Self::Never => write!(f, "never"),

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -1319,9 +1319,6 @@ pub enum DeclarationKind {
         signature: Signature,
         args: Vec<Operand>,
     },
-
-    /// Represents an untagged operand.
-    Untagged { operand: Operand },
 }
 
 impl Declaration {
@@ -1338,7 +1335,6 @@ impl Declaration {
 
                 args
             }
-            DeclarationKind::Untagged { operand } => operand.register_refs(),
         }
     }
 }
@@ -1363,7 +1359,6 @@ impl std::fmt::Display for Declaration {
                 "call indirect {ptr}({})",
                 args.iter().map(|arg| format!("{arg}")).collect::<Vec<_>>().join(", ")
             ),
-            DeclarationKind::Untagged { operand } => write!(f, "untagged {operand}"),
         }
     }
 }
@@ -1447,6 +1442,13 @@ impl Operand {
         }
     }
 
+    pub fn untagged_of(register: RegisterId) -> Self {
+        Self {
+            kind: OperandKind::Untagged { id: register },
+            location: Location::empty(),
+        }
+    }
+
     pub fn integer(bits: u8, signed: bool, value: i128) -> Self {
         Self {
             kind: OperandKind::Integer { bits, signed, value },
@@ -1459,9 +1461,10 @@ impl Operand {
         match &self.kind {
             OperandKind::Boolean { .. } => 1_usize,
             OperandKind::Integer { bits, .. } | OperandKind::Float { bits, .. } => usize::from(*bits) / 8,
-            OperandKind::Reference { .. } | OperandKind::SlotAddress { .. } | OperandKind::String { .. } => {
-                POINTER_SIZE
-            }
+            OperandKind::Reference { .. }
+            | OperandKind::Untagged { .. }
+            | OperandKind::SlotAddress { .. }
+            | OperandKind::String { .. } => POINTER_SIZE,
             OperandKind::Bitcast { target: ty, .. }
             | OperandKind::Load { loaded_type: ty, .. }
             | OperandKind::LoadField { field_type: ty, .. }
@@ -1509,6 +1512,9 @@ pub enum OperandKind {
 
     /// Represents a reference to an existing register.
     Reference { id: RegisterId },
+
+    /// Represents an untagged register.
+    Untagged { id: RegisterId },
 }
 
 impl Operand {
@@ -1518,7 +1524,9 @@ impl Operand {
         match &self.kind {
             OperandKind::Boolean { .. } => 1,
             OperandKind::Integer { bits, .. } | OperandKind::Float { bits, .. } => *bits,
-            OperandKind::Reference { .. } | OperandKind::String { .. } => std::mem::size_of::<*const u32>() as u8 * 8,
+            OperandKind::Reference { .. } | OperandKind::Untagged { .. } | OperandKind::String { .. } => {
+                std::mem::size_of::<*const u32>() as u8 * 8
+            }
             OperandKind::Bitcast { .. } => panic!("cannot get bitsize of bitcast operand"),
             OperandKind::Load { .. }
             | OperandKind::LoadField { .. }
@@ -1531,7 +1539,7 @@ impl Operand {
 
     pub fn register_refs(&self) -> Vec<RegisterId> {
         match &self.kind {
-            OperandKind::Load { id, .. } | OperandKind::Reference { id } => {
+            OperandKind::Load { id, .. } | OperandKind::Reference { id } | OperandKind::Untagged { id } => {
                 vec![*id]
             }
             OperandKind::LoadField { target, .. } => {
@@ -1559,7 +1567,9 @@ impl Operand {
             | OperandKind::Bitcast { .. }
             | OperandKind::LoadSlot { .. }
             | OperandKind::SlotAddress { .. } => false,
-            OperandKind::Reference { id } | OperandKind::Load { id, .. } => *id == register,
+            OperandKind::Reference { id } | OperandKind::Load { id, .. } | OperandKind::Untagged { id } => {
+                *id == register
+            }
             OperandKind::LoadField { target, .. } => *target == register,
         }
     }
@@ -1574,7 +1584,9 @@ impl Operand {
             | OperandKind::Bitcast { .. }
             | OperandKind::LoadSlot { .. }
             | OperandKind::SlotAddress { .. } => false,
-            OperandKind::Reference { id } | OperandKind::Load { id, .. } => *id == register,
+            OperandKind::Reference { id } | OperandKind::Load { id, .. } | OperandKind::Untagged { id } => {
+                *id == register
+            }
             OperandKind::LoadField { target, field_type, .. } => *target == register && field_type.is_reference_type(),
         }
     }
@@ -1595,6 +1607,13 @@ impl std::fmt::Display for Operand {
             OperandKind::LoadSlot { target, offset, .. } => write!(f, "*{target}[+x{offset:X}]"),
             OperandKind::SlotAddress { id, offset } => write!(f, "{id}[+x{offset:X}]"),
             OperandKind::String { value } => write!(f, "\"{value}\""),
+            OperandKind::Untagged { id } => {
+                if f.alternate() {
+                    write!(f, "untagged {id}")
+                } else {
+                    write!(f, "{id}")
+                }
+            }
         }
     }
 }

--- a/compiler/lume_mir_lower/src/builder/decl.rs
+++ b/compiler/lume_mir_lower/src/builder/decl.rs
@@ -93,9 +93,18 @@ impl Builder<'_, '_> {
 
     /// Declares a new register with the given register as untagged.
     pub(crate) fn declare_untagged(&mut self, id: RegisterId) -> RegisterId {
-        let value = Operand::untagged_of(id);
+        let current_block = self.func.current_block().id;
 
-        self.declare_operand(value, OperandRef::Implicit)
+        if let Some(untagged_id) = self.untagged_registers.get(&(self.func.current_block().id, id)) {
+            return *untagged_id;
+        }
+
+        let value = Operand::untagged_of(id);
+        let untagged = self.declare_operand(value, OperandRef::Implicit);
+
+        self.untagged_registers.insert((current_block, id), untagged);
+
+        untagged
     }
 }
 

--- a/compiler/lume_mir_lower/src/builder/decl.rs
+++ b/compiler/lume_mir_lower/src/builder/decl.rs
@@ -91,31 +91,11 @@ impl Builder<'_, '_> {
         }
     }
 
-    /// Declares a new register with the given value as untagged.
-    pub(crate) fn declare_untagged(&mut self, value: Operand) -> RegisterId {
-        let current_block = self.func.current_block().id;
+    /// Declares a new register with the given register as untagged.
+    pub(crate) fn declare_untagged(&mut self, id: RegisterId) -> RegisterId {
+        let value = Operand::untagged_of(id);
 
-        let tagged_register = if let &OperandKind::Reference { id } = &value.kind {
-            if let Some(untagged_id) = self.untagged_registers.get(&(self.func.current_block().id, id)) {
-                return *untagged_id;
-            }
-
-            Some(id)
-        } else {
-            None
-        };
-
-        let untagged_register = self.declare(Declaration {
-            location: value.location,
-            kind: Box::new(DeclarationKind::Untagged { operand: value }),
-        });
-
-        if let Some(tagged_register) = tagged_register {
-            self.untagged_registers
-                .insert((current_block, tagged_register), untagged_register);
-        }
-
-        untagged_register
+        self.declare_operand(value, OperandRef::Implicit)
     }
 }
 
@@ -352,21 +332,16 @@ impl Builder<'_, '_> {
                 location: vararg_loc,
             });
 
-        let vararg_arr_reg = self.declare_untagged(lume_mir::Operand::reference_of(vararg_arr_reg));
+        let vararg_arr_op = Operand::untagged_of(vararg_arr_reg);
 
         for arg in args {
-            self.call(
-                array_push_func_id,
-                vec![
-                    lume_mir::Operand::reference_of(vararg_arr_reg),
-                    arg,
-                    lume_mir::Operand::reference_of(metadata_reg),
-                ],
-                vararg_loc,
-            );
+            let vararg_arg = vararg_arr_op.clone();
+            let metadata_op = lume_mir::Operand::reference_of(metadata_reg);
+
+            self.call(array_push_func_id, vec![vararg_arg, arg, metadata_op], vararg_loc);
         }
 
-        new_args.push(lume_mir::Operand::reference_of(vararg_arr_reg));
+        new_args.push(vararg_arr_op);
         new_args
     }
 }
@@ -422,7 +397,8 @@ impl Builder<'_, '_> {
             lume_mir::OperandKind::Bitcast { source: id, .. }
             | lume_mir::OperandKind::Load { id, .. }
             | lume_mir::OperandKind::LoadField { target: id, .. }
-            | lume_mir::OperandKind::Reference { id } => self
+            | lume_mir::OperandKind::Reference { id }
+            | lume_mir::OperandKind::Untagged { id } => self
                 .mcx
                 .does_register_escape(&self.func, self.func.current_block().id, *id)
                 .escapes(),
@@ -461,6 +437,7 @@ impl Builder<'_, '_> {
         let location = value.location;
         let return_type = self.lower_type(expected_type);
 
+        let value = self.declare_operand(value, OperandRef::Implicit);
         let untagged_operand = self.declare_untagged(value);
         let loaded_operand = self.load_as(return_type, untagged_operand, location);
 

--- a/compiler/lume_mir_lower/src/builder/lower.rs
+++ b/compiler/lume_mir_lower/src/builder/lower.rs
@@ -236,6 +236,7 @@ fn assignment(builder: &mut Builder<'_, '_>, expr: &lume_tir::Assignment) -> lum
 
                 target_operand
             }
+            lume_mir::OperandKind::Untagged { .. } => panic!("bug!: attempted to assign untagged pointer"),
             lume_mir::OperandKind::Bitcast { .. } => panic!("bug!: attempted to assign bitcast"),
             lume_mir::OperandKind::SlotAddress { .. } => panic!("bug!: attempted to assign slot-address"),
             lume_mir::OperandKind::Boolean { .. }
@@ -319,14 +320,14 @@ fn construct(builder: &mut Builder<'_, '_>, expr: &lume_tir::Construct) -> lume_
         let struct_type = lume_mir::Type::structure(struct_name, field_types);
 
         let struct_alloc_reg = builder.alloca(struct_type.clone(), &expr.ty, expr.location);
-        let struct_untagged_reg = builder.declare_untagged(lume_mir::Operand::reference_of(struct_alloc_reg));
+        let struct_untagged_op = builder.declare_untagged(struct_alloc_reg);
 
         let mut offset = 0;
         for (field, size) in field_exprs.iter().zip(prop_sizes) {
             let (value_reg, _) = builder.use_value(&field.value);
             let value_op = builder.use_register(value_reg, field.value.location());
 
-            builder.store_field(struct_untagged_reg, value_op, offset, expr.location);
+            builder.store_field(struct_untagged_op, value_op, offset, expr.location);
 
             offset += size;
         }
@@ -365,7 +366,9 @@ fn call_expression(builder: &mut Builder<'_, '_>, expr: &lume_tir::Call) -> lume
             // If the argument is passed whilst tagged, the pointer would point to an
             // incorrect memory location.
             if is_ffi_call && builder.type_of_value(&arg_operand).requires_stack_map() {
-                arg_operand = lume_mir::Operand::reference_of(builder.declare_untagged(arg_operand));
+                let arg_register = builder.declare_operand(arg_operand, OperandRef::Implicit);
+
+                arg_operand = lume_mir::Operand::untagged_of(arg_register);
             }
 
             // Generic parameters are lowering into accepting pointer types, so all
@@ -568,7 +571,7 @@ fn literal(builder: &mut Builder<'_, '_>, expr: &lume_tir::Literal) -> lume_mir:
             let string_type = builder.tcx().type_of(expr.id).unwrap();
 
             let alloc_ptr = builder.alloca(lume_mir::Type::string(), &string_type, expr.location);
-            let untagged_ptr = builder.declare_untagged(lume_mir::Operand::reference_of(alloc_ptr));
+            let untagged_ptr = builder.declare_untagged(alloc_ptr);
 
             builder.store(untagged_ptr, string_operand, expr.location);
 
@@ -600,8 +603,10 @@ fn logical(builder: &mut Builder<'_, '_>, expr: &lume_tir::Logical) -> lume_mir:
 
 fn member_field(builder: &mut Builder<'_, '_>, expr: &lume_tir::Member) -> lume_mir::Operand {
     builder.with_current_block(|builder, _| {
-        let callee = expression(builder, &expr.callee);
-        let callee = builder.declare_untagged(callee);
+        let callee_expr = expression(builder, &expr.callee);
+        let callee_reg = builder.declare_operand(callee_expr, OperandRef::Implicit);
+
+        let callee = builder.declare_untagged(callee_reg);
 
         let field = builder.tcx().hir_expect_field(expr.field);
         let (offset, field_type) = builder.field_offset(field);
@@ -713,7 +718,7 @@ fn variant_expression(builder: &mut Builder<'_, '_>, expr: &lume_tir::Variant) -
 
         let enum_union_type = builder.union_of(&expr.ty);
         let variant_alloc = builder.alloca(enum_union_type, &expr.ty, expr.location);
-        let variant_untagged_reg = builder.declare_untagged(lume_mir::Operand::reference_of(variant_alloc));
+        let variant_untagged_reg = builder.declare_untagged(variant_alloc);
 
         let mut offset = 0;
 

--- a/compiler/lume_mir_lower/src/builder/mod.rs
+++ b/compiler/lume_mir_lower/src/builder/mod.rs
@@ -25,6 +25,12 @@ pub(crate) struct Builder<'mir, 'tcx> {
     /// Map of all metadata declarations within the current function, mapping
     /// each type to the containing register.
     metadata_registers: HashMap<(BasicBlockId, TypeMetadataId), RegisterId>,
+
+    /// Map of all untagging declarations within the current function, mapping
+    /// each tagged register to an already-untagged register.
+    ///
+    /// This is used to avoid re-untagging the same register multiple times.
+    untagged_registers: HashMap<(BasicBlockId, RegisterId), RegisterId>,
 }
 
 impl<'mir, 'tcx> Builder<'mir, 'tcx> {
@@ -33,6 +39,7 @@ impl<'mir, 'tcx> Builder<'mir, 'tcx> {
             mcx,
             func,
             metadata_registers: HashMap::new(),
+            untagged_registers: HashMap::new(),
         }
     }
 

--- a/compiler/lume_mir_lower/src/builder/mod.rs
+++ b/compiler/lume_mir_lower/src/builder/mod.rs
@@ -25,12 +25,6 @@ pub(crate) struct Builder<'mir, 'tcx> {
     /// Map of all metadata declarations within the current function, mapping
     /// each type to the containing register.
     metadata_registers: HashMap<(BasicBlockId, TypeMetadataId), RegisterId>,
-
-    /// Map of all untagging declarations within the current function, mapping
-    /// each tagged register to an already-untagged register.
-    ///
-    /// This is used to avoid re-untagging the same register multiple times.
-    untagged_registers: HashMap<(BasicBlockId, RegisterId), RegisterId>,
 }
 
 impl<'mir, 'tcx> Builder<'mir, 'tcx> {
@@ -39,7 +33,6 @@ impl<'mir, 'tcx> Builder<'mir, 'tcx> {
             mcx,
             func,
             metadata_registers: HashMap::new(),
-            untagged_registers: HashMap::new(),
         }
     }
 
@@ -205,7 +198,7 @@ impl Builder<'_, '_> {
         let operand_type = self.type_of_value(&value);
 
         let alloc = self.alloca(operand_type, ty, location);
-        let untagged = self.declare_untagged(lume_mir::Operand::reference_of(alloc));
+        let untagged = self.declare_untagged(alloc);
         self.func.current_block_mut().store(untagged, value, location);
 
         lume_mir::Operand {

--- a/compiler/lume_mir_lower/src/builder/pattern.rs
+++ b/compiler/lume_mir_lower/src/builder/pattern.rs
@@ -98,7 +98,7 @@ fn variant_pattern(
     variant: &lume_tir::VariantPattern,
     location: Location,
 ) -> lume_mir::Operand {
-    let untagged_op = builder.declare_untagged(lume_mir::Operand::reference_of(loaded_op));
+    let untagged_op = builder.declare_untagged(loaded_op);
 
     let discriminant_value = builder
         .tcx()
@@ -169,7 +169,7 @@ fn load_variant_subpattern(
     subpattern: &lume_tir::Pattern,
     field_idx: usize,
 ) -> lume_mir::Operand {
-    let untagged_op = builder.declare_untagged(lume_mir::Operand::reference_of(parent_operand));
+    let untagged_op = builder.declare_untagged(parent_operand);
 
     let field_offset = variant_field_offset(builder, parent_pattern.id, field_idx);
     let field_type = variant_field_type(builder, parent_pattern.id, field_idx);

--- a/compiler/lume_mir_lower/src/builder/ty.rs
+++ b/compiler/lume_mir_lower/src/builder/ty.rs
@@ -26,7 +26,9 @@ impl Builder<'_, '_> {
 
                 lume_mir::Type::pointer(slot_ty.to_owned())
             }
-            lume_mir::OperandKind::Reference { id } => self.func.registers.register_ty(*id).clone(),
+            lume_mir::OperandKind::Reference { id } | lume_mir::OperandKind::Untagged { id } => {
+                self.func.registers.register_ty(*id).clone()
+            }
         }
     }
 
@@ -82,7 +84,6 @@ impl Builder<'_, '_> {
             }
             lume_mir::DeclarationKind::Call { func_id, .. } => self.function_ret_type(*func_id),
             lume_mir::DeclarationKind::IndirectCall { signature, .. } => signature.return_type.clone(),
-            lume_mir::DeclarationKind::Untagged { operand } => self.type_of_value(operand),
         }
     }
 

--- a/compiler/lume_mir_lower/src/pass.rs
+++ b/compiler/lume_mir_lower/src/pass.rs
@@ -41,7 +41,11 @@ impl Builder<'_, '_> {
 
         #[allow(clippy::disallowed_macros, reason = "only used in debugging")]
         if self.mcx.should_dump_func(&self.func, Some(name)) {
-            println!("{}", self.func);
+            if self.mcx.gcx().session.options.dump_mir_full {
+                println!("{:#}", self.func);
+            } else {
+                println!("{}", self.func);
+            }
         }
 
         let mut pass = P::new();

--- a/compiler/lume_mir_lower/src/pass/mark_gc_refs.rs
+++ b/compiler/lume_mir_lower/src/pass/mark_gc_refs.rs
@@ -121,9 +121,7 @@ impl MarkObjectReferences {
                                     );
                                 }
                             }
-                            DeclarationKind::Cast { .. }
-                            | DeclarationKind::Intrinsic { .. }
-                            | DeclarationKind::Untagged { .. } => {}
+                            DeclarationKind::Cast { .. } | DeclarationKind::Intrinsic { .. } => {}
                         }
 
                         self.register_gc_object(func, block.id, inst_id, *register, Placement::After, location);
@@ -162,7 +160,7 @@ impl MarkObjectReferences {
         location: Location,
     ) {
         match &op.kind {
-            OperandKind::Load { id, .. } | OperandKind::Reference { id } => {
+            OperandKind::Load { id, .. } | OperandKind::Reference { id } | OperandKind::Untagged { id } => {
                 self.register_gc_object(func, block, inst_id, *id, placement, location);
             }
             OperandKind::LoadField { target, .. } => {

--- a/compiler/lume_mir_lower/src/pass/rename_ssa.rs
+++ b/compiler/lume_mir_lower/src/pass/rename_ssa.rs
@@ -235,7 +235,7 @@ impl RenameSsaVariables {
 
     fn update_regs_decl(decl: &mut Declaration, block: BasicBlockId, mapping: &mut RegisterMapping) {
         match decl.kind.as_mut() {
-            DeclarationKind::Operand(operand) | DeclarationKind::Untagged { operand } => {
+            DeclarationKind::Operand(operand) => {
                 Self::update_regs_op(operand, block, mapping);
             }
             DeclarationKind::Cast { operand, .. } => {
@@ -258,7 +258,7 @@ impl RenameSsaVariables {
 
     fn update_regs_op(op: &mut Operand, block: BasicBlockId, mapping: &mut RegisterMapping) {
         match &mut op.kind {
-            OperandKind::Load { id, .. } | OperandKind::Reference { id } => {
+            OperandKind::Load { id, .. } | OperandKind::Reference { id } | OperandKind::Untagged { id } => {
                 *id = mapping.get(block, *id);
             }
             OperandKind::LoadField { target, .. } => {

--- a/compiler/lume_mir_opt/src/pass.rs
+++ b/compiler/lume_mir_opt/src/pass.rs
@@ -43,6 +43,10 @@ pub(crate) fn run_all_passes(mcx: &mut MirQueryCtx, func_id: NodeId) {
 
     #[allow(clippy::disallowed_macros, reason = "only used in debugging")]
     if mcx.should_dump_func(func, None) {
-        println!("{func}");
+        if mcx.gcx().session.options.dump_mir_full {
+            println!("{func:#}");
+        } else {
+            println!("{func}");
+        }
     }
 }

--- a/compiler/lume_mir_opt/src/pass/heap_to_stack.rs
+++ b/compiler/lume_mir_opt/src/pass/heap_to_stack.rs
@@ -91,7 +91,7 @@ fn replace_reg_with_slot(
                 debug_assert_ne!(*id, register, "declaration instruction should have been skipped");
 
                 match decl.kind.as_mut() {
-                    DeclarationKind::Operand(operand) | DeclarationKind::Untagged { operand } => {
+                    DeclarationKind::Operand(operand) => {
                         replace_reg_in_op(operand, register, slot);
                     }
                     DeclarationKind::Cast { .. } => unreachable!("can't cast stack-slot"),
@@ -202,7 +202,7 @@ fn replace_reg_in_op(operand: &mut Operand, register: RegisterId, slot: SlotId) 
                 }
             }
         }
-        OperandKind::Reference { id } => {
+        OperandKind::Reference { id } | OperandKind::Untagged { id } => {
             if *id == register {
                 operand.kind = OperandKind::SlotAddress { id: slot, offset: 0 }
             }

--- a/compiler/lume_mir_queries/src/analysis/mod.rs
+++ b/compiler/lume_mir_queries/src/analysis/mod.rs
@@ -99,7 +99,7 @@ impl MirQueryCtx<'_> {
         for inst in block.instructions() {
             match &inst.kind {
                 InstructionKind::Let { register, decl, .. } => match decl.kind.as_ref() {
-                    DeclarationKind::Operand(operand) | DeclarationKind::Untagged { operand } => {
+                    DeclarationKind::Operand(operand) => {
                         if operand.stores_register(reg) {
                             self.does_register_escape_inner(func, block_id, *register, call_stack)?;
                         }

--- a/compiler/lume_session/src/lib.rs
+++ b/compiler/lume_session/src/lib.rs
@@ -63,6 +63,9 @@ pub struct Options {
     /// Defines which MIR functions to dump, if any.
     pub dump_mir_func: Vec<String>,
 
+    /// Defines whether the dumped MIR should include *all* instructions.
+    pub dump_mir_full: bool,
+
     /// Defines whether the generated codegen IR should be printed to `stdio`.
     pub dump_codegen_ir: bool,
 }
@@ -82,6 +85,7 @@ impl Default for Options {
             dump_hir: false,
             dump_mir: None,
             dump_mir_func: Vec::new(),
+            dump_mir_full: false,
             dump_codegen_ir: false,
         }
     }

--- a/tests/mir/autoboxing/generic_scalar_argument.mir
+++ b/tests/mir/autoboxing/generic_scalar_argument.mir
@@ -7,7 +7,7 @@ fn "main" () -> void {
 B0:
     let #0: metadata std::Int32 = metadata std::Int32()
     @0 = slot (12 bytes)
-    let #2: ptr i32 = untagged @0[+x0]
+    let #2: ptr i32 = @0[+x0]
     *#2 = 42_i32
     let #3: void = call foo(@0[+x0], #0)
     return

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch.mir
@@ -25,7 +25,7 @@ B0:
     mark object(#1)
     let #2: ptr Foo = untagged #1
     mark object(#2)
-    let #3: ptr std::Type = call std::type_of_value(#2, #0)
+    let #3: ptr std::Type = call std::type_of_value(untagged #1, #0)
     let #4: i32 = call Dynamic::func(#1, #3)
     return #4
 }

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch_default.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch_default.mir
@@ -20,7 +20,7 @@ B0:
     mark object(#1)
     let #2: ptr Foo = untagged #1
     mark object(#2)
-    let #3: ptr std::Type = call std::type_of_value(#2, #0)
+    let #3: ptr std::Type = call std::type_of_value(untagged #1, #0)
     let #4: i32 = call Dynamic::func(#1, #3)
     return #4
 }

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch_instance.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch_instance.mir
@@ -26,7 +26,7 @@ B0:
     mark object(#1)
     let #2: ptr Foo = untagged #1
     mark object(#2)
-    let #3: ptr std::Type = call std::type_of_value(#2, #0)
+    let #3: ptr std::Type = call std::type_of_value(untagged #1, #0)
     let #4: i32 = call Dynamic::func(#1, #3)
     return #4
 }

--- a/tools/manifold/src/mir.rs
+++ b/tools/manifold/src/mir.rs
@@ -21,6 +21,7 @@ fn build_mir(path: &TestPath, content: String) -> Result<String> {
 
     let pipeline = lume_driver::test_support::workspace(&*path.root)
         .with_option(|opts| opts.enable_incremental = false)
+        .with_option(|opts| opts.dump_mir_full = false)
         .with_file(
             "Arcfile",
             r#"
@@ -58,7 +59,7 @@ fn build_mir(path: &TestPath, content: String) -> Result<String> {
         .functions
         .values()
         .filter(|func| func.location.file.name.to_pathbuf().ends_with(file_name))
-        .map(ToString::to_string)
+        .map(|func| format!("{func:#}"))
         .collect();
 
     Ok(filtered_functions.join(""))


### PR DESCRIPTION
This PR makes the development and debugging of the MIR a little simpler by removing some of the noise in the MIR functions; most importantly hiding `mark object` instructions and hiding `untagged` from operands.

**diff between before/after:**
```diff
  fn "std::Boolean::to_string" (self: bool #0) -> ptr std::String {
  B0:
      if #0 goto B2 else B3
  B1(#2):  B2, B3
-     mark object(#2)
      return #2
  B2:  B0
      let #4: metadata std::String = metadata std::String()
      #5 = alloc string
-     mark object(#5)
-     let #6: ptr string = untagged #5
+     let #6: ptr string = #5
-     mark object(#6)
      *#6 = "true"
      goto B1(#5)
  B3:  B0
      let #8: metadata std::String = metadata std::String()
      #9 = alloc string
-     mark object(#9)
-     let #10: ptr string = untagged #9
+     let #10: ptr string = #9
-     mark object(#10)
      *#10 = "false"
      goto B1(#9)
  }
```

The "full" (exhaustive) MIR can still be dumped using the `--dump-mir-full` flag.