### PR TITLE
feat(parser): alternative pointer type syntax

### DIFF
--- a/compiler/lume_ast/src/generated/ast.rs
+++ b/compiler/lume_ast/src/generated/ast.rs
@@ -716,6 +716,7 @@ pub enum Type {
     NamedType(NamedType),
     ArrayType(ArrayType),
     SelfType(SelfType),
+    PointerType(PointerType),
 }
 impl AstNode for Type {
     fn cast(syntax: SyntaxNode) -> Option<Self> {
@@ -729,6 +730,9 @@ impl AstNode for Type {
             SyntaxKind::SELF_TYPE => {
                 Some(Self::SelfType(SelfType::cast(syntax).unwrap()))
             }
+            SyntaxKind::POINTER_TYPE => {
+                Some(Self::PointerType(PointerType::cast(syntax).unwrap()))
+            }
             _ => None,
         }
     }
@@ -737,6 +741,7 @@ impl AstNode for Type {
             Self::NamedType(it) => it.syntax(),
             Self::ArrayType(it) => it.syntax(),
             Self::SelfType(it) => it.syntax(),
+            Self::PointerType(it) => it.syntax(),
         }
     }
 }
@@ -2306,6 +2311,29 @@ impl AstNode for SelfType {
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         match syntax.kind() {
             SyntaxKind::SELF_TYPE => Some(SelfType { syntax }),
+            _ => None,
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
+pub struct PointerType {
+    syntax: SyntaxNode,
+}
+impl PointerType {
+    pub fn mul(&self) -> Option<SyntaxToken> {
+        crate::support::token(self.syntax(), SyntaxKind::MUL)
+    }
+    pub fn elemental(&self) -> Option<Type> {
+        crate::support::child(self.syntax())
+    }
+}
+impl AstNode for PointerType {
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        match syntax.kind() {
+            SyntaxKind::POINTER_TYPE => Some(PointerType { syntax }),
             _ => None,
         }
     }

--- a/compiler/lume_hir_lower/src/ty.rs
+++ b/compiler/lume_hir_lower/src/ty.rs
@@ -9,6 +9,7 @@ impl LoweringContext<'_> {
             lume_ast::Type::NamedType(t) => self.named_type(t),
             lume_ast::Type::ArrayType(t) => self.array_type(t),
             lume_ast::Type::SelfType(t) => self.alloc_self_type(self.location(t.location())),
+            lume_ast::Type::PointerType(t) => self.pointer_type(t),
         }
     }
 
@@ -92,6 +93,25 @@ impl LoweringContext<'_> {
             name,
             self_type: true,
             location,
+        };
+
+        self.map.types.insert(hir_type.id, hir_type.clone());
+        hir_type
+    }
+
+    #[tracing::instrument(level = "DEBUG", skip_all)]
+    fn pointer_type(&mut self, ty: lume_ast::PointerType) -> lume_hir::Type {
+        let id = self.next_node_id();
+
+        let mut name = lume_hir::hir_std_type_path!(Pointer);
+        let elemental_type = self.type_or_void(ty.elemental());
+        name.name.place_bound_types(vec![elemental_type]);
+
+        let hir_type = lume_hir::Type {
+            id: lume_hir::TypeId::from(id),
+            name,
+            self_type: false,
+            location: self.location(ty.location()),
         };
 
         self.map.types.insert(hir_type.id, hir_type.clone());

--- a/compiler/lume_parser/src/ty.rs
+++ b/compiler/lume_parser/src/ty.rs
@@ -7,6 +7,7 @@ impl Parser {
             SyntaxKind::IDENT => self.parse_named_type(),
             SyntaxKind::LEFT_BRACKET => self.parse_array_type(),
             SyntaxKind::SELF_TYPE => self.parse_self_type(),
+            SyntaxKind::MUL => self.parse_pointer_type(),
             _ => {
                 self.error_and_skip("expected type");
             }
@@ -35,6 +36,16 @@ impl Parser {
     fn parse_self_type(&mut self) {
         self.start_node(SyntaxKind::SELF_TYPE);
         self.consume(SyntaxKind::SELF_TYPE);
+        self.finish_node();
+    }
+
+    /// Parses a pointer type at the current cursor position.
+    fn parse_pointer_type(&mut self) {
+        self.start_node(SyntaxKind::POINTER_TYPE);
+
+        self.consume(SyntaxKind::MUL);
+        self.parse_type();
+
         self.finish_node();
     }
 

--- a/crates/lume_syntax/src/syntax_node.rs
+++ b/crates/lume_syntax/src/syntax_node.rs
@@ -162,6 +162,7 @@ pub enum SyntaxKind {
     NAMED_TYPE,
     ARRAY_TYPE,
     SELF_TYPE,
+    POINTER_TYPE,
 
     // Symbols
     ADD,

--- a/std/collections/roarray.lm
+++ b/std/collections/roarray.lm
@@ -28,7 +28,7 @@ pub struct ReadOnlyArray<T> {
     length: UInt64;
 
     /// Pointer to the memory allocated for the array items.
-    ptr: Pointer<T>;
+    ptr: *T;
 }
 
 impl<T> ReadOnlyArray<T> {
@@ -40,7 +40,7 @@ impl<T> ReadOnlyArray<T> {
             return Optional<T>::None;
         }
 
-        let offset = std::type_of<Pointer<T>>().size * index;
+        let offset = std::type_of<*T>().size * index;
         let value = self.ptr.read_offset(offset);
 
         Optional<T>::Some(value)

--- a/std/mem/alloc.lm
+++ b/std/mem/alloc.lm
@@ -1,15 +1,15 @@
 namespace std::mem
 
-import std (UInt64, Pointer)
+import std (UInt64)
 
 /// Allocates the given amount of bytes using the global allocator.
 ///
 /// The returned memory block may be larger than the requested size and
 /// it may not have it's content initialized and/or zeroed.
-pub fn unsafe external alloc<T>(size: UInt64) -> Pointer<T>
+pub fn unsafe external alloc<T>(size: UInt64) -> *T
 
 /// Reallocates an existing pointer to a new size.
-pub fn unsafe external realloc<T>(ptr: Pointer<T>, size: UInt64) -> Pointer<T>
+pub fn unsafe external realloc<T>(ptr: *T, size: UInt64) -> *T
 
 /// Deallocates a memory blocked, pointed to by `ptr`.
-pub fn unsafe external dealloc<T>(ptr: Pointer<T>)
+pub fn unsafe external dealloc<T>(ptr: *T)

--- a/std/mem/block.lm
+++ b/std/mem/block.lm
@@ -1,6 +1,5 @@
 namespace std::mem
 
-import std (Pointer)
 import std::ops (Dispose)
 
 /// A contiguous region of heap-allocated memory.
@@ -9,13 +8,13 @@ pub struct Block<T> {
     size: UInt64;
 
     /// Pointer to the start of the memory block, which exists within the heap.
-    ptr: Pointer<T>;
+    ptr: *T;
 }
 
 impl<T> Block<T> {
     /// Allocates a new `Block<T>`, with enough space for `count` items of type `T`.
     pub fn new(count: UInt64) -> Block<T> {
-        let elemental_size = std::type_of<Pointer<T>>().size;
+        let elemental_size = std::type_of<*T>().size;
         let total_size = elemental_size * count;
 
         let ptr = unsafe {
@@ -32,17 +31,17 @@ impl<T> Block<T> {
 
     /// Gets the amount of items that can be stored in the memory block.
     pub fn count(self) -> UInt64 {
-        self.size / std::type_of<Pointer<T>>().size
+        self.size / std::type_of<*T>().size
     }
 
     /// Gets the pointer of the memory block in bytes.
-    pub fn ptr(self) -> Pointer<T> {
+    pub fn ptr(self) -> *T {
         self.ptr
     }
 
     /// Re-allocates the `Block<T>` to have enough space for `new_count` items of type `T`.
     pub fn expand(self, new_count: UInt64) {
-        let elemental_size = std::type_of<Pointer<T>>().size;
+        let elemental_size = std::type_of<*T>().size;
         let total_size = elemental_size * new_count;
 
         self.ptr = unsafe {
@@ -53,7 +52,7 @@ impl<T> Block<T> {
 
     /// Reads the value from the block, placed at the given index.
     pub fn get(self, index: UInt64) -> T {
-        let offset = std::type_of<Pointer<T>>().size * index;
+        let offset = std::type_of<*T>().size * index;
         if offset >= self.size {
             std::process::bail("index out of bounds");
         }
@@ -65,7 +64,7 @@ impl<T> Block<T> {
 
     /// Writes a new value to the block, placed at the given index.
     pub fn set(self, value: T, index: UInt64) {
-        let offset = std::type_of<Pointer<T>>().size * index;
+        let offset = std::type_of<*T>().size * index;
         if offset >= self.size {
             std::process::bail("index out of bounds");
         }

--- a/std/mem/box.lm
+++ b/std/mem/box.lm
@@ -1,11 +1,10 @@
 namespace std::mem
 
-import std (Pointer)
 import std::ops (Dispose)
 
 /// A heap-allocated value, containing a value of type `T`.
 pub struct Box<T> {
-    ptr: Pointer<T>;
+    ptr: *T;
 }
 
 impl<T> Box<T> {
@@ -24,7 +23,7 @@ impl<T> Box<T> {
     }
 
     /// Gets the inner pointer, which the box is referring to.
-    pub fn ptr(self) -> Pointer<T> {
+    pub fn ptr(self) -> *T {
         self.ptr
     }
 }

--- a/std/pointer.lm
+++ b/std/pointer.lm
@@ -13,12 +13,18 @@ pub struct Void {}
 ///
 /// Pointers cannot be created manually - they can only be created by the compiler itself, as a result
 /// of creating a built-in type or some other memory allocation.
+///
+/// Pointers can be typed using either the fully-qualifed path, `Pointer<T>`, or the same syntax as in
+/// other C-like languages, `*T`:
+/// ```lm
+/// let ptr: *UInt8 = std::Pointer<UInt8>::null();
+/// ```
 pub struct Pointer<T> {}
 
 impl<T> Pointer<T> {
     /// Creates a null pointer of type `T`.
     ![external(name = "std::mem::ptr_null")]
-    pub fn unsafe external null() -> Pointer<T>
+    pub fn unsafe external null() -> *T
 
     /// Gets the pointer as a reference, pointing to the same address as the
     /// pointer itself.

--- a/std/string.lm
+++ b/std/string.lm
@@ -14,5 +14,5 @@ namespace std
 /// "Hello world!"
 /// ```
 pub struct String {
-    inner: Pointer<UInt8>;
+    inner: *UInt8;
 }

--- a/tools/fmt/src/lib.rs
+++ b/tools/fmt/src/lib.rs
@@ -1372,6 +1372,10 @@ impl<'cfg, 'src> Formatter<'cfg, 'src> {
                 Some(elemental) => concat(vec![str("["), self.ty(elemental), str("]")]),
                 None => string(ty.as_text()),
             },
+            Type::PointerType(ty) => match ty.elemental() {
+                Some(elemental) => str("*").append(self.ty(elemental)),
+                None => string(ty.as_text()),
+            },
         }
     }
 

--- a/tools/grammar/lume.ungram
+++ b/tools/grammar/lume.ungram
@@ -328,6 +328,7 @@ Type =
   NamedType
 | ArrayType
 | SelfType
+| PointerType
 
 NamedType =
   Path
@@ -337,6 +338,9 @@ ArrayType =
 
 SelfType =
   'Self'
+
+PointerType =
+  '*' elemental:Type
 
 //
 // Paths


### PR DESCRIPTION
Adds `*T` syntax for pointer types, which desugars directly into `std::Pointer<T>`