### PR TITLE
refactor(mir): add `lume_mir::Patcher` for larger MIR function changes

### DIFF
--- a/compiler/lume_codegen/src/inst.rs
+++ b/compiler/lume_codegen/src/inst.rs
@@ -23,7 +23,7 @@ impl LowerFunction<'_> {
         let cg_block = self.builder.create_block();
 
         for reg_id in mir_block.parameters() {
-            let reg_ty = self.func.registers.register_ty(reg_id);
+            let reg_ty = self.func.registers.local_type(reg_id);
             let param_ty = self.backend.cl_type_of(reg_ty);
 
             let param_value = self.builder.append_block_param(cg_block, param_ty);

--- a/compiler/lume_codegen/src/lib.rs
+++ b/compiler/lume_codegen/src/lib.rs
@@ -846,7 +846,7 @@ impl<'ctx> LowerFunction<'ctx> {
     }
 
     pub(crate) fn icast(&mut self, reg: RegisterId, to: u8) -> Value {
-        let lume_mir::TypeKind::Integer { bits: from, signed } = self.func.registers.register_ty(reg).kind else {
+        let lume_mir::TypeKind::Integer { bits: from, signed } = self.func.registers.local_type(reg).kind else {
             panic!("bug!: attempted to use icast on non-integer register");
         };
 
@@ -910,7 +910,7 @@ impl<'ctx> LowerFunction<'ctx> {
     }
 
     pub(crate) fn fcast(&mut self, reg: RegisterId, to: u8) -> Value {
-        let lume_mir::TypeKind::Float { bits: from } = self.func.registers.register_ty(reg).kind else {
+        let lume_mir::TypeKind::Float { bits: from } = self.func.registers.local_type(reg).kind else {
             panic!("bug!: attempted to use fcast on non-float register");
         };
 

--- a/compiler/lume_codegen/src/value.rs
+++ b/compiler/lume_codegen/src/value.rs
@@ -8,7 +8,7 @@ impl LowerFunction<'_> {
         match decl.kind.as_ref() {
             lume_mir::DeclarationKind::Operand(op) => self.cg_operand(op),
             lume_mir::DeclarationKind::Cast { operand, bits } => {
-                let operand_ty = self.func.registers.register_ty(*operand);
+                let operand_ty = self.func.registers.local_type(*operand);
                 let is_int = matches!(operand_ty.kind, lume_mir::TypeKind::Integer { .. });
 
                 if is_int {

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -294,7 +294,7 @@ impl Function {
 
     /// Gets a reference to the register with the given ID.
     pub fn register(&self, id: RegisterId) -> &Register {
-        self.registers.register(id)
+        self.registers.local(id)
     }
 
     /// Gets a reference to the block that the register with the given ID is
@@ -631,7 +631,7 @@ pub struct BasicBlock {
 
     /// Defines all the input registers, which the block takes
     /// as input from predecessor blocks.
-    parameters: IndexSet<RegisterId>,
+    pub parameters: IndexSet<RegisterId>,
 
     /// Defines all non-terminator instructions in the block.
     pub instructions: IndexMap<InstructionId, Instruction>,
@@ -1062,6 +1062,12 @@ pub struct LocalRegister {
     pub register: RegisterId,
 }
 
+impl std::fmt::Display for LocalRegister {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.block, self.register)
+    }
+}
+
 /// Defines a register within a block, which can hold a value of a specific
 /// type.
 ///
@@ -1072,9 +1078,7 @@ pub struct LocalRegister {
 #[derive(Serialize, Deserialize, Default, Debug, Hash, Clone, PartialEq, Eq)]
 pub struct Register {
     pub id: RegisterId,
-
-    /// Defines the type of the register.
-    pub ty: Type,
+    pub value_type: Type,
 
     /// Defines which block the register belongs to.
     pub block: Option<BasicBlockId>,
@@ -1082,43 +1086,44 @@ pub struct Register {
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct Registers {
-    regs: Vec<Register>,
+    pub locals: IndexMap<RegisterId, Register>,
 }
 
 impl Registers {
     /// Gets a reference to the [`Register`] with the given ID.
     #[track_caller]
     pub fn next_id(&self) -> RegisterId {
-        let next = self.regs.iter().map(|reg| reg.id.as_usize() + 1).max().unwrap_or(0);
+        let next = self.locals.values().map(|reg| reg.id.as_usize() + 1).max().unwrap_or(0);
 
         RegisterId(next)
     }
 
     /// Gets a reference to the [`Register`] with the given ID.
     #[track_caller]
-    pub fn register(&self, id: RegisterId) -> &Register {
-        &self.regs[id.0]
+    pub fn local(&self, id: RegisterId) -> &Register {
+        self.locals.get(&id).unwrap()
     }
 
     /// Gets a mutable reference to the [`Register`] with the given ID.
     #[track_caller]
-    pub fn register_mut(&mut self, id: RegisterId) -> &mut Register {
-        &mut self.regs[id.0]
+    pub fn local_mut(&mut self, id: RegisterId) -> &mut Register {
+        self.locals.get_mut(&id).unwrap()
     }
 
     /// Gets a reference to the type of the [`Register`] with the given ID.
     #[track_caller]
-    pub fn register_ty(&self, id: RegisterId) -> &Type {
-        &self.register(id).ty
+    pub fn local_type(&self, id: RegisterId) -> &Type {
+        &self.local(id).value_type
     }
 
     /// Allocates a new register with the given type and block.
-    #[tracing::instrument(level = "TRACE", skip_all, fields(%ty, %block), ret)]
-    pub fn allocate(&mut self, ty: Type, block: BasicBlockId) -> RegisterId {
+    #[tracing::instrument(level = "TRACE", skip_all, fields(%value_type, %block), ret)]
+    pub fn allocate(&mut self, value_type: Type, block: BasicBlockId) -> RegisterId {
         let id = self.next_id();
-        self.regs.push(Register {
+
+        self.locals.insert(id, Register {
             id,
-            ty,
+            value_type,
             block: Some(block),
         });
 
@@ -1126,27 +1131,27 @@ impl Registers {
     }
 
     /// Allocates a new parameter register with the given type.
-    #[tracing::instrument(level = "TRACE", skip_all, fields(%ty), ret)]
-    pub fn allocate_param(&mut self, ty: Type) -> RegisterId {
+    #[tracing::instrument(level = "TRACE", skip_all, fields(%value_type), ret)]
+    pub fn allocate_param(&mut self, value_type: Type) -> RegisterId {
         let id = self.next_id();
-        self.regs.push(Register { id, ty, block: None });
+
+        self.locals.insert(id, Register {
+            id,
+            value_type,
+            block: None,
+        });
 
         id
     }
 
-    /// Iterates over all registers.
-    pub fn iter(&self) -> impl Iterator<Item = &Register> {
-        self.regs.iter()
-    }
-
     /// Iterates over all parameter registers.
     pub fn iter_params(&self) -> impl Iterator<Item = &Register> {
-        self.regs.iter().filter(|reg| reg.block.is_none())
+        self.locals.values().filter(|reg| reg.block.is_none())
     }
 
-    /// Replaces all the existing registers within the function.
-    pub fn replace_all(&mut self, replacement: impl Iterator<Item = Register>) {
-        self.regs = replacement.collect();
+    /// Iterates over all registers.
+    pub fn locals(&self) -> impl Iterator<Item = &Register> {
+        self.locals.values()
     }
 }
 

--- a/compiler/lume_mir_lower/src/builder/ty.rs
+++ b/compiler/lume_mir_lower/src/builder/ty.rs
@@ -27,7 +27,7 @@ impl Builder<'_, '_> {
                 lume_mir::Type::pointer(slot_ty.to_owned())
             }
             lume_mir::OperandKind::Reference { id } | lume_mir::OperandKind::Untagged { id } => {
-                self.func.registers.register_ty(*id).clone()
+                self.func.registers.local_type(*id).clone()
             }
         }
     }
@@ -77,7 +77,7 @@ impl Builder<'_, '_> {
                 },
             },
             lume_mir::DeclarationKind::Cast { operand, bits } => {
-                let operand_ty = self.func.registers.register_ty(*operand);
+                let operand_ty = self.func.registers.local_type(*operand);
                 let signed = operand_ty.is_signed();
 
                 lume_mir::Type::integer(*bits, signed)

--- a/compiler/lume_mir_lower/src/dynamic/mod.rs
+++ b/compiler/lume_mir_lower/src/dynamic/mod.rs
@@ -83,7 +83,7 @@ impl<'shim, 'mir, 'tcx> DynamicShimBuilder<'shim, 'mir, 'tcx> {
             let mut arguments = Vec::with_capacity(self.parameters.len());
 
             for &param in &self.parameters {
-                let parameter_type = &builder.func.register(param).ty;
+                let parameter_type = &builder.func.register(param).value_type;
                 let parameter = builder.func.add_block_parameter(block_id, parameter_type.clone());
 
                 arguments.push(lume_mir::Operand::reference_of(parameter));

--- a/compiler/lume_mir_lower/src/pass/mark_gc_refs.rs
+++ b/compiler/lume_mir_lower/src/pass/mark_gc_refs.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use lume_span::Location;
+use lume_mir_queries::patch::{Placement, RelativePlacement};
 
 use super::*;
 
@@ -9,26 +9,11 @@ struct ObjectReference {
     /// The block in which the instruction was found.
     pub block: BasicBlockId,
 
-    /// The ID of the target instruction, which referenced the object.
-    pub target: InstructionId,
-
     /// The placement of the GC reference instruction.
     pub placement: Placement,
 
     /// The register which needs to marked as an object.
     pub register: RegisterId,
-
-    /// The location to use for the GC reference instruction.
-    pub location: Location,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Placement {
-    /// The reference should be placed before the target instruction.
-    Before,
-
-    /// The reference should be placed after the target instruction.
-    After,
 }
 
 /// Attempts to mark managed objects as GC references, by adding
@@ -56,35 +41,23 @@ impl Pass for MarkObjectReferences {
     }
 
     /// Executes the pass on the given function.
-    fn execute(&mut self, _mcx: &MirQueryCtx, func: &mut Function) {
+    fn execute(&mut self, mcx: &MirQueryCtx, func: &mut Function) {
         self.find_object_references(func);
 
-        while let Some(reference) = self.references.pop() {
-            let block = func.block_mut(reference.block);
+        let mut patcher = mcx.patcher(func);
 
-            let inst = lume_mir::Instruction {
-                kind: lume_mir::InstructionKind::ObjectRegister {
-                    register: reference.register,
-                },
-                location: reference.location,
+        while let Some(reference) = self.references.pop() {
+            let placement = RelativePlacement {
+                relative: reference.placement,
+                block_id: reference.block,
             };
 
-            let key = InstructionId(block.instructions.len());
-            let offset = block.instructions.get_index_of(&reference.target).unwrap_or(0);
-
-            match reference.placement {
-                Placement::Before => {
-                    block.instructions.insert_before(offset, key, inst);
-                }
-                Placement::After => {
-                    if offset == block.instructions.len() {
-                        block.instructions.insert(key, inst);
-                    } else {
-                        block.instructions.insert_before(offset + 1, key, inst);
-                    }
-                }
-            }
+            patcher.add_instruction(placement, lume_mir::InstructionKind::ObjectRegister {
+                register: reference.register,
+            });
         }
+
+        patcher.apply(func);
     }
 }
 
@@ -92,53 +65,36 @@ impl MarkObjectReferences {
     fn find_object_references(&mut self, func: &Function) {
         for block in func.blocks.values() {
             for param in block.parameters() {
-                self.register_gc_object(func, block.id, InstructionId(0), param, Placement::After, func.location);
+                self.register_gc_object(func, block.id, param, Placement::Beginning);
             }
 
             for (&inst_id, inst) in &block.instructions {
-                let location = inst.location;
-
                 match &inst.kind {
                     InstructionKind::Let { register, decl, .. } => {
                         match decl.kind.as_ref() {
-                            DeclarationKind::Operand(operand) => self.find_object_references_operand(
-                                func,
-                                block.id,
-                                inst_id,
-                                operand,
-                                Placement::Before,
-                                location,
-                            ),
+                            DeclarationKind::Operand(operand) => {
+                                self.find_object_references_operand(func, block.id, operand, Placement::Before {
+                                    inst: inst_id,
+                                });
+                            }
                             DeclarationKind::Call { args, .. } | DeclarationKind::IndirectCall { args, .. } => {
                                 for arg in args {
-                                    self.find_object_references_operand(
-                                        func,
-                                        block.id,
-                                        inst_id,
-                                        arg,
-                                        Placement::Before,
-                                        location,
-                                    );
+                                    self.find_object_references_operand(func, block.id, arg, Placement::Before {
+                                        inst: inst_id,
+                                    });
                                 }
                             }
                             DeclarationKind::Cast { .. } | DeclarationKind::Intrinsic { .. } => {}
                         }
 
-                        self.register_gc_object(func, block.id, inst_id, *register, Placement::After, location);
+                        self.register_gc_object(func, block.id, *register, Placement::After { inst: inst_id });
                     }
                     InstructionKind::Allocate { register, .. } => {
-                        self.register_gc_object(func, block.id, inst_id, *register, Placement::After, location);
+                        self.register_gc_object(func, block.id, *register, Placement::After { inst: inst_id });
                     }
                     InstructionKind::Store { target, value } | InstructionKind::StoreField { target, value, .. } => {
-                        self.register_gc_object(func, block.id, inst_id, *target, Placement::Before, location);
-                        self.find_object_references_operand(
-                            func,
-                            block.id,
-                            inst_id,
-                            value,
-                            Placement::Before,
-                            location,
-                        );
+                        self.register_gc_object(func, block.id, *target, Placement::Before { inst: inst_id });
+                        self.find_object_references_operand(func, block.id, value, Placement::Before { inst: inst_id });
                     }
                     InstructionKind::ObjectRegister { .. }
                     | InstructionKind::CreateSlot { .. }
@@ -154,17 +110,15 @@ impl MarkObjectReferences {
         &mut self,
         func: &Function,
         block: BasicBlockId,
-        inst_id: InstructionId,
         op: &Operand,
         placement: Placement,
-        location: Location,
     ) {
         match &op.kind {
             OperandKind::Load { id, .. } | OperandKind::Reference { id } | OperandKind::Untagged { id } => {
-                self.register_gc_object(func, block, inst_id, *id, placement, location);
+                self.register_gc_object(func, block, *id, placement);
             }
             OperandKind::LoadField { target, .. } => {
-                self.register_gc_object(func, block, inst_id, *target, placement, location);
+                self.register_gc_object(func, block, *target, placement);
             }
             OperandKind::Bitcast { .. }
             | OperandKind::Boolean { .. }
@@ -180,10 +134,8 @@ impl MarkObjectReferences {
         &mut self,
         func: &Function,
         block: BasicBlockId,
-        inst: InstructionId,
         register: RegisterId,
         placement: Placement,
-        location: Location,
     ) -> bool {
         if self.marked.contains(&register) || !func.registers.local_type(register).requires_stack_map() {
             return false;
@@ -192,9 +144,7 @@ impl MarkObjectReferences {
         self.marked.insert(register);
         self.references.push(ObjectReference {
             block,
-            target: inst,
             placement,
-            location,
             register,
         });
 

--- a/compiler/lume_mir_lower/src/pass/mark_gc_refs.rs
+++ b/compiler/lume_mir_lower/src/pass/mark_gc_refs.rs
@@ -185,7 +185,7 @@ impl MarkObjectReferences {
         placement: Placement,
         location: Location,
     ) -> bool {
-        if self.marked.contains(&register) || !func.registers.register_ty(register).requires_stack_map() {
+        if self.marked.contains(&register) || !func.registers.local_type(register).requires_stack_map() {
             return false;
         }
 

--- a/compiler/lume_mir_lower/src/pass/rename_ssa.rs
+++ b/compiler/lume_mir_lower/src/pass/rename_ssa.rs
@@ -1,6 +1,3 @@
-use indexmap::IndexMap;
-use lume_span::Interned;
-
 use super::*;
 
 /// Some backend implementations, specifically Cranelift, does not allow using
@@ -48,23 +45,8 @@ use super::*;
 ///     #2: i32 = *(#0, #1)
 ///     return #2
 /// ```
-///
-/// <div class="warning">
-///
-/// **Here be dragons!**
-///
-/// On a more serious note, this is quite possibly the most error-prone part of
-/// the MIR lowering process. The reason for this is mostly because of the
-/// awkward implementation of "phi" nodes between blocks in some instances.
-///
-/// This pass should receive a refactor at some point, but is currently not
-/// planned.
-///
-/// </div>
 #[derive(Default, Debug)]
-pub(crate) struct RenameSsaVariables {
-    register_counter: usize,
-}
+pub(crate) struct RenameSsaVariables;
 
 impl Pass for RenameSsaVariables {
     fn name() -> &'static str {
@@ -73,231 +55,40 @@ impl Pass for RenameSsaVariables {
 
     /// Creates a new instance of the pass without default settings.
     fn new() -> Self {
-        Self::default()
+        Self
     }
 
     /// Executes the pass on the given function.
-    fn execute(&mut self, _mcx: &MirQueryCtx, func: &mut Function) {
-        let mut new_registers = func
-            .registers
-            .iter()
-            .filter(|reg| reg.block.is_none())
-            .cloned()
-            .collect::<Vec<Register>>();
+    fn execute(&mut self, mcx: &MirQueryCtx, func: &mut Function) {
+        let mut patcher = mcx.patcher(func);
 
-        let mut register_mapping = RegisterMapping::new(func.name);
+        for parameter_idx in 0..func.signature.parameters.len() {
+            let renamed_register = patcher.next_local();
 
-        for block in func.blocks.values_mut() {
-            let block_id = block.id;
-
-            for param_idx in 0..func.signature.parameters.len() {
-                let param_reg = func.registers.register_mut(RegisterId::new(param_idx));
-
-                self.rename_register_index(param_reg.id, block_id, &mut register_mapping);
-            }
-
-            let mut block_parameters = block.parameters().collect::<Vec<RegisterId>>();
-            for param in &mut block_parameters {
-                self.rename_register_index_mut(param, block_id, &mut register_mapping);
-            }
-
-            block.parameter_replace_all(block_parameters.into_iter());
-
-            for inst in block.instructions_mut() {
-                self.update_regs_inst(inst, block_id, &mut register_mapping);
-            }
-
-            if let Some(term) = block.terminator_mut() {
-                Self::update_regs_term(term, block_id, &mut register_mapping);
-            }
-
-            for (old, new) in &register_mapping.mapping {
-                let old_reg = func.registers.register(old.0);
-
-                if new_registers.len() <= new.as_usize() {
-                    new_registers.resize_with(new.as_usize() + 1, Register::default);
-                }
-
-                new_registers[new.as_usize()] = lume_mir::Register {
-                    id: *new,
-                    ty: old_reg.ty.clone(),
-                    block: Some(block.id),
-                };
-            }
-
-            register_mapping.mapping.clear();
+            patcher.rename_register(BasicBlockId(0), RegisterId::new(parameter_idx), renamed_register);
         }
 
-        func.registers.replace_all(new_registers.into_iter());
-    }
-}
-
-impl RenameSsaVariables {
-    fn rename_register_index(
-        &mut self,
-        old: RegisterId,
-        block: BasicBlockId,
-        mapping: &mut RegisterMapping,
-    ) -> RegisterId {
-        let new = RegisterId::new(self.register_counter);
-
-        mapping.insert(block, old, new);
-        self.register_counter += 1;
-
-        new
-    }
-
-    fn rename_register_index_mut(
-        &mut self,
-        old: &mut RegisterId,
-        block: BasicBlockId,
-        mapping: &mut RegisterMapping,
-    ) -> RegisterId {
-        let new = RegisterId::new(self.register_counter);
-
-        mapping.insert(block, *old, new);
-        self.register_counter += 1;
-
-        *old = new;
-
-        new
-    }
-
-    fn update_regs_inst(&mut self, inst: &mut Instruction, block: BasicBlockId, mapping: &mut RegisterMapping) {
-        match &mut inst.kind {
-            InstructionKind::Let { register, decl, .. } => {
-                self.rename_register_index_mut(register, block, mapping);
-
-                Self::update_regs_decl(decl, block, mapping);
+        for (&block_id, block) in &func.blocks {
+            for &parameter in &block.parameters {
+                let renamed_register = patcher.next_local();
+                patcher.rename_register(block_id, parameter, renamed_register);
             }
-            InstructionKind::Allocate { register, metadata, .. } => {
-                self.rename_register_index_mut(register, block, mapping);
-                *metadata = mapping.get(block, *metadata);
-            }
-            InstructionKind::Store { target, value } | InstructionKind::StoreField { target, value, .. } => {
-                *target = mapping.get(block, *target);
-                Self::update_regs_op(value, block, mapping);
-            }
-            InstructionKind::ObjectRegister { register } => {
-                *register = mapping.get(block, *register);
-            }
-            InstructionKind::CreateSlot { .. } | InstructionKind::StoreSlot { .. } => {}
-        }
-    }
 
-    fn update_regs_term(term: &mut Terminator, block: BasicBlockId, mapping: &mut RegisterMapping) {
-        match &mut term.kind {
-            TerminatorKind::Return(op) => {
-                if let Some(value) = op {
-                    Self::update_regs_op(value, block, mapping);
-                }
-            }
-            TerminatorKind::Branch(site) => {
-                for arg in &mut site.arguments {
-                    Self::update_regs_op(arg, block, mapping);
-                }
-            }
-            TerminatorKind::ConditionalBranch {
-                condition,
-                then_block,
-                else_block,
-            } => {
-                *condition = mapping.get(block, *condition);
-
-                for arg in &mut then_block.arguments {
-                    Self::update_regs_op(arg, block, mapping);
-                }
-
-                for arg in &mut else_block.arguments {
-                    Self::update_regs_op(arg, block, mapping);
-                }
-            }
-            TerminatorKind::Switch {
-                operand,
-                arms,
-                fallback,
-            } => {
-                *operand = mapping.get(block, *operand);
-
-                for arm in arms {
-                    for arg in &mut arm.1.arguments {
-                        Self::update_regs_op(arg, block, mapping);
+            for inst in block.instructions() {
+                match &inst.kind {
+                    InstructionKind::Let { register, .. } | InstructionKind::Allocate { register, .. } => {
+                        let renamed_register = patcher.next_local();
+                        patcher.rename_register(block_id, *register, renamed_register);
                     }
-                }
-
-                for arg in &mut fallback.arguments {
-                    Self::update_regs_op(arg, block, mapping);
-                }
-            }
-            TerminatorKind::Unreachable => {}
-        }
-    }
-
-    fn update_regs_decl(decl: &mut Declaration, block: BasicBlockId, mapping: &mut RegisterMapping) {
-        match decl.kind.as_mut() {
-            DeclarationKind::Operand(operand) => {
-                Self::update_regs_op(operand, block, mapping);
-            }
-            DeclarationKind::Cast { operand, .. } => {
-                *operand = mapping.get(block, *operand);
-            }
-            DeclarationKind::Call { args, .. } | DeclarationKind::Intrinsic { args, .. } => {
-                for arg in args {
-                    Self::update_regs_op(arg, block, mapping);
-                }
-            }
-            DeclarationKind::IndirectCall { ptr, args, .. } => {
-                *ptr = mapping.get(block, *ptr);
-
-                for arg in args {
-                    Self::update_regs_op(arg, block, mapping);
+                    InstructionKind::Store { .. }
+                    | InstructionKind::StoreField { .. }
+                    | InstructionKind::ObjectRegister { .. }
+                    | InstructionKind::CreateSlot { .. }
+                    | InstructionKind::StoreSlot { .. } => {}
                 }
             }
         }
-    }
 
-    fn update_regs_op(op: &mut Operand, block: BasicBlockId, mapping: &mut RegisterMapping) {
-        match &mut op.kind {
-            OperandKind::Load { id, .. } | OperandKind::Reference { id } | OperandKind::Untagged { id } => {
-                *id = mapping.get(block, *id);
-            }
-            OperandKind::LoadField { target, .. } => {
-                *target = mapping.get(block, *target);
-            }
-            OperandKind::Bitcast { source, .. } => {
-                *source = mapping.get(block, *source);
-            }
-            OperandKind::Boolean { .. }
-            | OperandKind::Integer { .. }
-            | OperandKind::Float { .. }
-            | OperandKind::String { .. }
-            | OperandKind::LoadSlot { .. }
-            | OperandKind::SlotAddress { .. } => {}
-        }
-    }
-}
-
-struct RegisterMapping {
-    pub func_name: Interned<String>,
-    pub mapping: IndexMap<(RegisterId, BasicBlockId), RegisterId>,
-}
-
-impl RegisterMapping {
-    pub fn new(func_name: Interned<String>) -> Self {
-        Self {
-            func_name,
-            mapping: IndexMap::new(),
-        }
-    }
-
-    pub fn get(&mut self, block: BasicBlockId, id: RegisterId) -> RegisterId {
-        *self
-            .mapping
-            .get(&(id, block))
-            .unwrap_or_else(|| panic!("could not find register {id} in {block} in {}", self.func_name))
-    }
-
-    pub fn insert(&mut self, block: BasicBlockId, old: RegisterId, new: RegisterId) {
-        self.mapping.insert((old, block), new);
+        patcher.apply(func);
     }
 }

--- a/compiler/lume_mir_queries/src/lib.rs
+++ b/compiler/lume_mir_queries/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod analysis;
 pub mod lookup;
 pub mod opts;
+pub mod patch;
 
 use lume_architect::DatabaseContext;
 use lume_mir::ModuleMap;

--- a/compiler/lume_mir_queries/src/patch.rs
+++ b/compiler/lume_mir_queries/src/patch.rs
@@ -1,0 +1,263 @@
+use indexmap::IndexMap;
+use lume_mir::*;
+use lume_span::Interned;
+
+use crate::*;
+
+impl<'tcx> MirQueryCtx<'tcx> {
+    /// Create a new MIR patcher for the given MIR function.
+    #[inline]
+    pub fn patcher(&self, func: &Function) -> Patcher<'_, 'tcx> {
+        Patcher::new(self, func)
+    }
+}
+
+struct RegisterMapping {
+    pub func_name: Interned<String>,
+
+    /// Mapping between old register and new register. The block for the new
+    /// register is the same as within the key.
+    pub mapping: IndexMap<LocalRegister, RegisterId>,
+}
+
+impl RegisterMapping {
+    pub fn new(func_name: Interned<String>) -> Self {
+        Self {
+            func_name,
+            mapping: IndexMap::new(),
+        }
+    }
+
+    #[track_caller]
+    pub fn get(&self, block: BasicBlockId, id: RegisterId) -> RegisterId {
+        match self.mapping.get(&LocalRegister { register: id, block }) {
+            Some(register_id) => *register_id,
+            None => panic!("could not find register {block}.{id} in `{}`", self.func_name),
+        }
+    }
+
+    pub fn insert(&mut self, old: LocalRegister, new: RegisterId) {
+        assert!(self.mapping.insert(old, new).is_none());
+    }
+}
+
+pub struct Patcher<'mcx, 'tcx> {
+    mcx: &'mcx MirQueryCtx<'tcx>,
+    mapped_registers: RegisterMapping,
+
+    next_local: usize,
+}
+
+impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
+    pub fn new(mcx: &'mcx MirQueryCtx<'tcx>, func: &Function) -> Self {
+        Self {
+            mcx,
+            mapped_registers: RegisterMapping::new(func.name),
+            next_local: 0,
+        }
+    }
+
+    pub fn next_local(&mut self) -> RegisterId {
+        let local = RegisterId::new(self.next_local);
+        self.next_local += 1;
+
+        local
+    }
+
+    #[tracing::instrument(
+        level = "TRACE",
+        skip_all,
+        fields(func = self.mapped_registers.func_name.as_str(), %block, %old, %new)
+    )]
+    pub fn rename_register(&mut self, block: BasicBlockId, old: RegisterId, new: RegisterId) {
+        self.mapped_registers
+            .insert(LocalRegister { block, register: old }, new);
+    }
+
+    pub fn apply(self, target: &mut Function) {
+        // Handle cases where a renamed register crosses a block-boundary, causing two
+        // blocks to use the same register:
+        // ```mir
+        // fn "foo" () {
+        // B0:
+        //     let #1: u64 = 0_u64
+        //     goto B1(#1)
+        // B1(#1):  B0
+        //     return #1
+        // }
+        // ```
+        // Even though `#1` is clearly defined in `B0`, it is used within `B1` and is
+        // passed in as a block parameter. This causes issues when renaming a register
+        // within a specific block
+        //
+        // Imagine we want to rename `B1.#1` to `B1.#2` (which we do in the `rename_ssa`
+        // MIR pass), we have to duplicate the register, since it would become distinct
+        // from `B0.#1`. We do this *before* applying the renaming, since we need the
+        // type of the source register.
+        let mut new_registers = IndexMap::new();
+
+        for (&local_source, &dest_register) in &self.mapped_registers.mapping {
+            // If the function's register already exists in the correct block, skip over it.
+            if let Some(register) = target.registers.locals.get(&local_source.register)
+                && register.block.is_some_and(|block| block == local_source.block)
+            {
+                continue;
+            }
+
+            let value_type = target.registers.local_type(local_source.register).clone();
+
+            new_registers.insert(dest_register, Register {
+                id: dest_register,
+                value_type,
+                block: Some(local_source.block),
+            });
+        }
+
+        // Replace all register references within the function's blocks, parameters,
+        // instructions and terminator.
+        for (&block_id, block) in &mut target.blocks {
+            for parameter in std::mem::take(&mut block.parameters) {
+                let replacement_id = self.mapped_registers.get(block_id, parameter);
+                assert!(block.parameters.insert(replacement_id));
+            }
+
+            for inst in block.instructions_mut() {
+                rename::rename_inst(inst, block_id, &self.mapped_registers);
+            }
+
+            if let Some(term) = block.terminator_mut() {
+                rename::rename_term(term, block_id, &self.mapped_registers);
+            }
+        }
+
+        // Update the register mapping within the function's own registers, so we can
+        // still look them up in later passes.
+        for (register_id, mut register) in std::mem::take(&mut target.registers.locals) {
+            let block = register.block.unwrap_or_default();
+            let replacement_id = self.mapped_registers.get(block, register_id);
+            register.id = replacement_id;
+
+            assert!(target.registers.locals.insert(replacement_id, register).is_none());
+        }
+
+        // Insert all the new registers at the end. Since the locals are indexed in a
+        // map, their position does not matter.
+        target.registers.locals.extend(new_registers);
+    }
+}
+
+mod rename {
+    use super::*;
+
+    pub(super) fn rename_inst(inst: &mut Instruction, block: BasicBlockId, mapping: &RegisterMapping) {
+        match &mut inst.kind {
+            InstructionKind::Let { register, decl, .. } => {
+                *register = mapping.get(block, *register);
+                rename_decl(decl, block, mapping);
+            }
+            InstructionKind::Allocate { register, metadata, .. } => {
+                *register = mapping.get(block, *register);
+                *metadata = mapping.get(block, *metadata);
+            }
+            InstructionKind::Store { target, value } | InstructionKind::StoreField { target, value, .. } => {
+                *target = mapping.get(block, *target);
+                rename_operand(value, block, mapping);
+            }
+            InstructionKind::ObjectRegister { register } => {
+                *register = mapping.get(block, *register);
+            }
+            InstructionKind::CreateSlot { .. } | InstructionKind::StoreSlot { .. } => {}
+        }
+    }
+
+    pub(super) fn rename_term(term: &mut Terminator, block: BasicBlockId, mapping: &RegisterMapping) {
+        match &mut term.kind {
+            TerminatorKind::Return(op) => {
+                if let Some(value) = op {
+                    rename_operand(value, block, mapping);
+                }
+            }
+            TerminatorKind::Branch(site) => {
+                for arg in &mut site.arguments {
+                    rename_operand(arg, block, mapping);
+                }
+            }
+            TerminatorKind::ConditionalBranch {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                *condition = mapping.get(block, *condition);
+
+                for arg in &mut then_block.arguments {
+                    rename_operand(arg, block, mapping);
+                }
+
+                for arg in &mut else_block.arguments {
+                    rename_operand(arg, block, mapping);
+                }
+            }
+            TerminatorKind::Switch {
+                operand,
+                arms,
+                fallback,
+            } => {
+                *operand = mapping.get(block, *operand);
+
+                for arm in arms {
+                    for arg in &mut arm.1.arguments {
+                        rename_operand(arg, block, mapping);
+                    }
+                }
+
+                for arg in &mut fallback.arguments {
+                    rename_operand(arg, block, mapping);
+                }
+            }
+            TerminatorKind::Unreachable => {}
+        }
+    }
+
+    pub(super) fn rename_decl(decl: &mut Declaration, block: BasicBlockId, mapping: &RegisterMapping) {
+        match decl.kind.as_mut() {
+            DeclarationKind::Operand(operand) => {
+                rename_operand(operand, block, mapping);
+            }
+            DeclarationKind::Cast { operand, .. } => {
+                *operand = mapping.get(block, *operand);
+            }
+            DeclarationKind::Call { args, .. } | DeclarationKind::Intrinsic { args, .. } => {
+                for arg in args {
+                    rename_operand(arg, block, mapping);
+                }
+            }
+            DeclarationKind::IndirectCall { ptr, args, .. } => {
+                *ptr = mapping.get(block, *ptr);
+
+                for arg in args {
+                    rename_operand(arg, block, mapping);
+                }
+            }
+        }
+    }
+
+    pub(super) fn rename_operand(op: &mut Operand, block: BasicBlockId, mapping: &RegisterMapping) {
+        match &mut op.kind {
+            OperandKind::Load { id, .. } | OperandKind::Reference { id } | OperandKind::Untagged { id } => {
+                *id = mapping.get(block, *id);
+            }
+            OperandKind::LoadField { target, .. } => {
+                *target = mapping.get(block, *target);
+            }
+            OperandKind::Bitcast { source, .. } => {
+                *source = mapping.get(block, *source);
+            }
+            OperandKind::Boolean { .. }
+            | OperandKind::Integer { .. }
+            | OperandKind::Float { .. }
+            | OperandKind::String { .. }
+            | OperandKind::LoadSlot { .. }
+            | OperandKind::SlotAddress { .. } => {}
+        }
+    }
+}

--- a/compiler/lume_mir_queries/src/patch.rs
+++ b/compiler/lume_mir_queries/src/patch.rs
@@ -41,9 +41,29 @@ impl RegisterMapping {
     }
 }
 
+/// Represents a placement within a basic block, relative to some instruction.
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelativePlacement {
+    pub block_id: BasicBlockId,
+    pub relative: Placement,
+}
+
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Placement {
+    /// The target should be placed at the beginning of the block.
+    Beginning,
+
+    /// The reference should be placed before the target instruction.
+    Before { inst: InstructionId },
+
+    /// The reference should be placed after the target instruction.
+    After { inst: InstructionId },
+}
+
 pub struct Patcher<'mcx, 'tcx> {
-    mcx: &'mcx MirQueryCtx<'tcx>,
+    pub mcx: &'mcx MirQueryCtx<'tcx>,
     mapped_registers: RegisterMapping,
+    new_instructions: Vec<(RelativePlacement, InstructionKind)>,
 
     next_local: usize,
 }
@@ -53,6 +73,7 @@ impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
         Self {
             mcx,
             mapped_registers: RegisterMapping::new(func.name),
+            new_instructions: Vec::new(),
             next_local: 0,
         }
     }
@@ -74,7 +95,26 @@ impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
             .insert(LocalRegister { block, register: old }, new);
     }
 
-    pub fn apply(self, target: &mut Function) {
+    #[tracing::instrument(level = "TRACE", skip_all)]
+    pub fn add_instruction(&mut self, placement: RelativePlacement, kind: InstructionKind) {
+        self.new_instructions.push((placement, kind));
+    }
+
+    pub fn apply(mut self, target: &mut Function) {
+        if !self.new_instructions.is_empty() {
+            add_instruction::apply(&mut self, target);
+        }
+
+        if !self.mapped_registers.mapping.is_empty() {
+            rename::apply(&mut self, target);
+        }
+    }
+}
+
+mod rename {
+    use super::*;
+
+    pub fn apply(p: &mut Patcher<'_, '_>, target: &mut Function) {
         // Handle cases where a renamed register crosses a block-boundary, causing two
         // blocks to use the same register:
         // ```mir
@@ -96,7 +136,7 @@ impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
         // type of the source register.
         let mut new_registers = IndexMap::new();
 
-        for (&local_source, &dest_register) in &self.mapped_registers.mapping {
+        for (&local_source, &dest_register) in &p.mapped_registers.mapping {
             // If the function's register already exists in the correct block, skip over it.
             if let Some(register) = target.registers.locals.get(&local_source.register)
                 && register.block.is_some_and(|block| block == local_source.block)
@@ -117,16 +157,16 @@ impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
         // instructions and terminator.
         for (&block_id, block) in &mut target.blocks {
             for parameter in std::mem::take(&mut block.parameters) {
-                let replacement_id = self.mapped_registers.get(block_id, parameter);
+                let replacement_id = p.mapped_registers.get(block_id, parameter);
                 assert!(block.parameters.insert(replacement_id));
             }
 
             for inst in block.instructions_mut() {
-                rename::rename_inst(inst, block_id, &self.mapped_registers);
+                rename::rename_inst(inst, block_id, &p.mapped_registers);
             }
 
             if let Some(term) = block.terminator_mut() {
-                rename::rename_term(term, block_id, &self.mapped_registers);
+                rename::rename_term(term, block_id, &p.mapped_registers);
             }
         }
 
@@ -134,7 +174,7 @@ impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
         // still look them up in later passes.
         for (register_id, mut register) in std::mem::take(&mut target.registers.locals) {
             let block = register.block.unwrap_or_default();
-            let replacement_id = self.mapped_registers.get(block, register_id);
+            let replacement_id = p.mapped_registers.get(block, register_id);
             register.id = replacement_id;
 
             assert!(target.registers.locals.insert(replacement_id, register).is_none());
@@ -144,10 +184,6 @@ impl<'mcx, 'tcx> Patcher<'mcx, 'tcx> {
         // map, their position does not matter.
         target.registers.locals.extend(new_registers);
     }
-}
-
-mod rename {
-    use super::*;
 
     pub(super) fn rename_inst(inst: &mut Instruction, block: BasicBlockId, mapping: &RegisterMapping) {
         match &mut inst.kind {
@@ -258,6 +294,60 @@ mod rename {
             | OperandKind::String { .. }
             | OperandKind::LoadSlot { .. }
             | OperandKind::SlotAddress { .. } => {}
+        }
+    }
+}
+
+mod add_instruction {
+    use super::*;
+
+    pub fn apply(p: &mut Patcher<'_, '_>, target: &mut Function) {
+        for (placement, instruction_kind) in std::mem::take(&mut p.new_instructions) {
+            let block = target.block(placement.block_id);
+            let location = match placement.relative {
+                Placement::Beginning => target.location,
+                Placement::Before { inst } | Placement::After { inst } => {
+                    block.instructions.get(&inst).unwrap().location
+                }
+            };
+
+            let new_instruction_id = InstructionId(block.instructions.len());
+            let new_instruction = lume_mir::Instruction {
+                kind: instruction_kind,
+                location,
+            };
+
+            let block = target.block_mut(placement.block_id);
+
+            match placement.relative {
+                Placement::Beginning => {
+                    block.instructions.shift_insert(0, new_instruction_id, new_instruction);
+                }
+
+                Placement::Before { inst } | Placement::After { inst } => {
+                    let target_offset = block.instructions.get_index_of(&inst).unwrap_or(0);
+
+                    match placement.relative {
+                        Placement::Before { .. } => {
+                            block
+                                .instructions
+                                .insert_before(target_offset, new_instruction_id, new_instruction);
+                        }
+                        Placement::After { .. } => {
+                            if target_offset == block.instructions.len() {
+                                block.instructions.insert(new_instruction_id, new_instruction);
+                            } else {
+                                block.instructions.insert_before(
+                                    target_offset + 1,
+                                    new_instruction_id,
+                                    new_instruction,
+                                );
+                            }
+                        }
+                        Placement::Beginning => unreachable!(),
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/mir/autoboxing/generic_is_variant.mir
+++ b/tests/mir/autoboxing/generic_is_variant.mir
@@ -7,14 +7,14 @@ B0:
     let #5: box void = *#2[+x1]
     let #6: bool = &&(#4, true)
     if #6 goto B1(#5) else B2
-B1(#8):  B0
-    let #9: box void = untagged #8
-    let #10: i32 = *#9
-    let #11: i32 = #10
-    return #10
+B1(#7):  B0
+    let #8: box void = untagged #7
+    let #9: i32 = *#8
+    let #10: i32 = #9
+    return #9
 B2:  B0
-    let #13: i32 = 0_i32
-    let #14: bool = false
+    let #11: i32 = 0_i32
+    let #12: bool = false
     return 0_i32
 }
 

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch.mir
@@ -4,9 +4,9 @@ B0:
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
 B1(#4, #5):  B0
-    let #6: i32 = call indirect #4(#5)
     mark object(#4)
     mark object(#5)
+    let #6: i32 = call indirect #4(#5)
     return #6
 B2:  B0
     unreachable

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch.mir
@@ -3,11 +3,11 @@ B0:
     let #2: u64 = call std::find_method_on(-1075694710286076807_u64, #1)
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
-B1(#6, #7):  B0
-    let #8: i32 = call indirect #6(#7)
-    mark object(#6)
-    mark object(#7)
-    return #8
+B1(#4, #5):  B0
+    let #6: i32 = call indirect #4(#5)
+    mark object(#4)
+    mark object(#5)
+    return #6
 B2:  B0
     unreachable
 }

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch_default.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch_default.mir
@@ -3,14 +3,14 @@ B0:
     let #2: u64 = call std::find_method_on(-1075694710286076807_u64, #1)
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
-B1(#6, #7):  B0
-    let #8: i32 = call indirect #6(#7)
-    mark object(#6)
-    mark object(#7)
-    return #8
+B1(#4, #5):  B0
+    let #6: i32 = call indirect #4(#5)
+    mark object(#4)
+    mark object(#5)
+    return #6
 B2:  B0
-    let #11: i32 = 15_i32
-    return #11
+    let #7: i32 = 15_i32
+    return #7
 }
 
 fn "main" () -> i32 {

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch_default.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch_default.mir
@@ -4,9 +4,9 @@ B0:
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
 B1(#4, #5):  B0
-    let #6: i32 = call indirect #4(#5)
     mark object(#4)
     mark object(#5)
+    let #6: i32 = call indirect #4(#5)
     return #6
 B2:  B0
     let #7: i32 = 15_i32

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch_instance.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch_instance.mir
@@ -4,9 +4,9 @@ B0:
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
 B1(#4, #5):  B0
-    let #6: i32 = call indirect #4(#5)
     mark object(#4)
     mark object(#5)
+    let #6: i32 = call indirect #4(#5)
     return #6
 B2:  B0
     let #7: i32 = 15_i32

--- a/tests/mir/dynamic_dispatch/dynamic_dispatch_instance.mir
+++ b/tests/mir/dynamic_dispatch/dynamic_dispatch_instance.mir
@@ -3,14 +3,14 @@ B0:
     let #2: u64 = call std::find_method_on(-1075694710286076807_u64, #1)
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
-B1(#6, #7):  B0
-    let #8: i32 = call indirect #6(#7)
-    mark object(#6)
-    mark object(#7)
-    return #8
+B1(#4, #5):  B0
+    let #6: i32 = call indirect #4(#5)
+    mark object(#4)
+    mark object(#5)
+    return #6
 B2:  B0
-    let #11: i32 = 15_i32
-    return #11
+    let #7: i32 = 15_i32
+    return #7
 }
 
 fn "Foo::func" (self: ptr Foo #0) -> i32 {

--- a/tests/mir/metadata/trait_method_dynamic.mir
+++ b/tests/mir/metadata/trait_method_dynamic.mir
@@ -4,8 +4,8 @@ B0:
     let #2: bool = ==(#1, 0_u64)
     if #2 goto B2 else B1(#1)
 B1(#3):  B0
-    let #4: ptr void = call indirect #3()
     mark object(#3)
+    let #4: ptr void = call indirect #3()
     mark object(#4)
     return #4
 B2:  B0

--- a/tests/mir/metadata/trait_method_dynamic.mir
+++ b/tests/mir/metadata/trait_method_dynamic.mir
@@ -3,11 +3,11 @@ B0:
     let #1: u64 = call std::find_method_on(1751523730200737563_u64, #0)
     let #2: bool = ==(#1, 0_u64)
     if #2 goto B2 else B1(#1)
-B1(#4):  B0
-    let #5: ptr void = call indirect #4()
+B1(#3):  B0
+    let #4: ptr void = call indirect #3()
+    mark object(#3)
     mark object(#4)
-    mark object(#5)
-    return #5
+    return #4
 B2:  B0
     unreachable
 }

--- a/tests/mir/metadata/trait_method_dynamic_typed.mir
+++ b/tests/mir/metadata/trait_method_dynamic_typed.mir
@@ -3,10 +3,10 @@ B0:
     let #2: u64 = call std::find_method_on(1751523730200737563_u64, #1)
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
-B1(#6, #7):  B0
-    let #8: box void = call indirect #6(#7)
-    mark object(#6)
-    return #8
+B1(#4, #5):  B0
+    let #6: box void = call indirect #4(#5)
+    mark object(#4)
+    return #6
 B2:  B0
     unreachable
 }

--- a/tests/mir/metadata/trait_method_dynamic_typed.mir
+++ b/tests/mir/metadata/trait_method_dynamic_typed.mir
@@ -4,8 +4,8 @@ B0:
     let #3: bool = ==(#2, 0_u64)
     if #3 goto B2 else B1(#2, #0)
 B1(#4, #5):  B0
-    let #6: box void = call indirect #4(#5)
     mark object(#4)
+    let #6: box void = call indirect #4(#5)
     return #6
 B2:  B0
     unreachable


### PR DESCRIPTION
Refactors some of the ugliest MIR passes into a versatile `Patcher` struct, coalescing some of the pass-specific functionality into a single struct.