### PR TITLE
feat(mono): add collector for monomorphizing MIR functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "lume_session",
  "lume_span",
  "lume_types",
+ "serde",
  "tracing",
 ]
 
@@ -2093,6 +2094,7 @@ dependencies = [
  "lume_session",
  "lume_span",
  "lume_typech",
+ "lume_types",
  "tracing",
 ]
 
@@ -2104,6 +2106,7 @@ dependencies = [
  "lume_errors",
  "lume_hir",
  "lume_infer",
+ "lume_mangle",
  "lume_mir",
  "lume_mir_queries",
  "lume_session",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,6 +2043,7 @@ name = "lume_mir"
 version = "0.1.3"
 dependencies = [
  "indexmap",
+ "lume_infer",
  "lume_session",
  "lume_span",
  "lume_type_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "lume_architect",
  "lume_errors",
  "lume_errors_test",
+ "lume_hash",
  "lume_hir",
  "lume_hir_lower",
  "lume_session",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,7 @@ dependencies = [
  "lume_mangle",
  "lume_mir",
  "lume_mir_queries",
+ "lume_mono",
  "lume_session",
  "lume_span",
  "lume_tir",
@@ -2091,6 +2092,23 @@ dependencies = [
  "lume_session",
  "lume_span",
  "lume_typech",
+ "tracing",
+]
+
+[[package]]
+name = "lume_mono"
+version = "0.1.3"
+dependencies = [
+ "indexmap",
+ "lume_errors",
+ "lume_hir",
+ "lume_infer",
+ "lume_mir",
+ "lume_mir_queries",
+ "lume_session",
+ "lume_span",
+ "lume_typech",
+ "lume_types",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ regex = { version = "=1.11.1" }
 semver = { version = "^1", features = ["serde"] }
 serde = { version = "^1.0.228", features = ["derive"] }
 serde_json = { version = "^1.0.140" }
+smallvec = { version = "1.15" }
 tracing = { version = "0.1.44", features = ["max_level_trace", "release_max_level_off"] }
 
 [workspace.lints.clippy]

--- a/compiler/lume_cli/src/opts.rs
+++ b/compiler/lume_cli/src/opts.rs
@@ -9,7 +9,7 @@ pub struct BuildOptions {
     #[arg(value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub path: Option<PathBuf>,
 
-    /// Whether to disable incremental compilation.
+    /// Whether to allow incremental compilation.
     #[arg(long)]
     pub incremental: bool,
 

--- a/compiler/lume_cli/src/opts.rs
+++ b/compiler/lume_cli/src/opts.rs
@@ -11,7 +11,7 @@ pub struct BuildOptions {
 
     /// Whether to disable incremental compilation.
     #[arg(long)]
-    pub no_incremental: bool,
+    pub incremental: bool,
 
     /// Generate source-level debug information
     #[arg(
@@ -130,7 +130,7 @@ impl BuildOptions {
         lume_session::Options {
             print_type_context: self.dev.print_type_ctx,
             export_private_nodes: false,
-            enable_incremental: !self.no_incremental,
+            enable_incremental: self.incremental,
             optimize: match self.optimize.as_str() {
                 "0" => OptimizationLevel::O0,
                 "1" => OptimizationLevel::O1,

--- a/compiler/lume_codegen/src/lib.rs
+++ b/compiler/lume_codegen/src/lib.rs
@@ -476,13 +476,13 @@ impl CraneliftBackend {
 
         let mut stack_maps = WriterRelocate::new(endian);
 
-        for (def, func) in &self.declared_funcs {
-            let func_def = self.context.functions.get(def).unwrap();
+        for (&def, func) in &self.declared_funcs {
+            let func_def = self.context.function(def);
             if func_def.signature.external {
                 continue;
             }
 
-            let Some(metadata) = function_metadata.get(def) else {
+            let Some(metadata) = function_metadata.get(&def) else {
                 continue;
             };
 

--- a/compiler/lume_hir/src/lib.rs
+++ b/compiler/lume_hir/src/lib.rs
@@ -1522,7 +1522,7 @@ pub struct DerefExpr {
     pub location: Location,
 }
 
-#[derive(Location, Hash, Debug, Clone, PartialEq)]
+#[derive(Location, Hash, Debug, Clone, PartialEq, Eq)]
 pub struct RefExpr {
     pub id: NodeId,
     pub target: NodeId,

--- a/compiler/lume_hir/src/lib.rs
+++ b/compiler/lume_hir/src/lib.rs
@@ -15,7 +15,7 @@ pub mod macros;
 
 pub use lang::LangItem;
 pub use map::Map;
-pub use visitor::{Visitor, traverse};
+pub use visitor::{Visitor, traverse, traverse_node};
 
 pub const SELF_PARAM_NAME: &str = "self";
 pub const SELF_TYPE_NAME: &str = "Self";
@@ -1383,7 +1383,7 @@ pub enum ExpressionKind {
     Variant(Variant),
 }
 
-#[derive(Hash, Debug, Clone, Copy, PartialEq)]
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallExpression<'a> {
     /// Defines a call which was invoked without any callee or receiver.
     ///
@@ -1529,7 +1529,7 @@ pub struct RefExpr {
     pub location: Location,
 }
 
-#[derive(Location, Hash, Debug, Clone, PartialEq)]
+#[derive(Location, Hash, Debug, Clone, PartialEq, Eq)]
 pub struct StaticCall {
     pub id: NodeId,
     pub name: Path,
@@ -1555,7 +1555,7 @@ impl StaticCall {
     }
 }
 
-#[derive(Location, Hash, Debug, Clone, PartialEq)]
+#[derive(Location, Hash, Debug, Clone, PartialEq, Eq)]
 pub struct InstanceCall {
     pub id: NodeId,
     pub callee: NodeId,
@@ -1580,7 +1580,7 @@ impl InstanceCall {
     }
 }
 
-#[derive(Location, Hash, Debug, Clone, PartialEq)]
+#[derive(Location, Hash, Debug, Clone, PartialEq, Eq)]
 pub struct IntrinsicCall {
     pub id: NodeId,
     pub kind: IntrinsicKind,

--- a/compiler/lume_hir/src/macros.rs
+++ b/compiler/lume_hir/src/macros.rs
@@ -51,12 +51,12 @@ macro_rules! hir_std_type_path {
     };
 }
 
-/// Creates a new HIR path to a HIR method, on a named HIR type.
+/// Creates a new HIR path to a HIR function, on a named HIR type.
 #[macro_export]
-macro_rules! hir_method_path {
+macro_rules! hir_func_path {
     ($name:ident) => {
         $crate::Path::rooted(
-            $crate::PathSegment::ty(stringify!($name)),
+            $crate::PathSegment::callable(stringify!($name)),
         )
     };
     ($($namespace:ident)::+, $name:ident) => {
@@ -66,7 +66,7 @@ macro_rules! hir_method_path {
                     $crate::PathSegment::namespace(stringify!($namespace)),
                 ),*
             ]),
-            $crate::PathSegment::ty(stringify!($name)),
+            $crate::PathSegment::callable(stringify!($name)),
         )
     };
 }

--- a/compiler/lume_hir/src/visitor.rs
+++ b/compiler/lume_hir/src/visitor.rs
@@ -3,38 +3,38 @@ use lume_errors::Result;
 use crate::*;
 
 /// Visitor trait for traversing the HIR map.
-pub trait Visitor {
-    fn visit_node(&mut self, _node: &Node) -> Result<()> {
+pub trait Visitor<'hir> {
+    fn visit_node(&mut self, _node: &'hir Node) -> Result<()> {
         Ok(())
     }
 
-    fn visit_type(&mut self, _ty: &Type) -> Result<()> {
+    fn visit_type(&mut self, _ty: &'hir Type) -> Result<()> {
         Ok(())
     }
 
-    fn visit_stmt(&mut self, _stmt: &Statement) -> Result<()> {
+    fn visit_stmt(&mut self, _stmt: &'hir Statement) -> Result<()> {
         Ok(())
     }
 
-    fn visit_expr(&mut self, _expr: &Expression) -> Result<()> {
+    fn visit_expr(&mut self, _expr: &'hir Expression) -> Result<()> {
         Ok(())
     }
 
-    fn visit_pattern(&mut self, _pattern: &Pattern) -> Result<()> {
+    fn visit_pattern(&mut self, _pattern: &'hir Pattern) -> Result<()> {
         Ok(())
     }
 
-    fn visit_path(&mut self, _path: &Path) -> Result<()> {
+    fn visit_path(&mut self, _path: &'hir Path) -> Result<()> {
         Ok(())
     }
 
-    fn visit_identifier(&mut self, _ident: &Identifier) -> Result<()> {
+    fn visit_identifier(&mut self, _ident: &'hir Identifier) -> Result<()> {
         Ok(())
     }
 }
 
 /// Traverses the given HIR map using the provided visitor.
-pub fn traverse<V: Visitor>(hir: &Map, visitor: &mut V) -> Result<()> {
+pub fn traverse<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V) -> Result<()> {
     for node in hir.nodes().values() {
         traverse_node(hir, visitor, node)?;
     }
@@ -42,7 +42,7 @@ pub fn traverse<V: Visitor>(hir: &Map, visitor: &mut V) -> Result<()> {
     Ok(())
 }
 
-fn traverse_node<V: Visitor>(hir: &Map, visitor: &mut V, node: &Node) -> Result<()> {
+pub fn traverse_node<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V, node: &'hir Node) -> Result<()> {
     visitor.visit_node(node)?;
 
     match node {
@@ -182,7 +182,11 @@ fn traverse_node<V: Visitor>(hir: &Map, visitor: &mut V, node: &Node) -> Result<
     Ok(())
 }
 
-fn traverse_type_params<V: Visitor, I: Iterator<Item = NodeId>>(hir: &Map, visitor: &mut V, iter: I) -> Result<()> {
+fn traverse_type_params<'hir, V: Visitor<'hir>, I: Iterator<Item = NodeId>>(
+    hir: &'hir Map,
+    visitor: &mut V,
+    iter: I,
+) -> Result<()> {
     for type_param_id in iter {
         let Node::Type(TypeDefinition::TypeParameter(type_param)) = hir.expect_node(type_param_id)? else {
             continue;
@@ -198,7 +202,7 @@ fn traverse_type_params<V: Visitor, I: Iterator<Item = NodeId>>(hir: &Map, visit
     Ok(())
 }
 
-fn traverse_stmt<V: Visitor>(hir: &Map, visitor: &mut V, stmt: &Statement) -> Result<()> {
+fn traverse_stmt<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V, stmt: &'hir Statement) -> Result<()> {
     visitor.visit_stmt(stmt)?;
 
     match &stmt.kind {
@@ -233,7 +237,7 @@ fn traverse_stmt<V: Visitor>(hir: &Map, visitor: &mut V, stmt: &Statement) -> Re
     Ok(())
 }
 
-fn traverse_expr<V: Visitor>(hir: &Map, visitor: &mut V, expr: &Expression) -> Result<()> {
+fn traverse_expr<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V, expr: &'hir Expression) -> Result<()> {
     visitor.visit_expr(expr)?;
 
     match &expr.kind {
@@ -322,7 +326,7 @@ fn traverse_expr<V: Visitor>(hir: &Map, visitor: &mut V, expr: &Expression) -> R
     Ok(())
 }
 
-fn traverse_pattern<V: Visitor>(hir: &Map, visitor: &mut V, pattern: &Pattern) -> Result<()> {
+fn traverse_pattern<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V, pattern: &'hir Pattern) -> Result<()> {
     visitor.visit_pattern(pattern)?;
 
     match &pattern.kind {
@@ -345,13 +349,13 @@ fn traverse_pattern<V: Visitor>(hir: &Map, visitor: &mut V, pattern: &Pattern) -
     Ok(())
 }
 
-fn traverse_type<V: Visitor>(hir: &Map, visitor: &mut V, ty: &Type) -> Result<()> {
+fn traverse_type<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V, ty: &'hir Type) -> Result<()> {
     visitor.visit_type(ty)?;
 
     traverse_path(hir, visitor, &ty.name)
 }
 
-fn traverse_path<V: Visitor>(hir: &Map, visitor: &mut V, path: &Path) -> Result<()> {
+fn traverse_path<'hir, V: Visitor<'hir>>(hir: &'hir Map, visitor: &mut V, path: &'hir Path) -> Result<()> {
     visitor.visit_path(path)?;
 
     for root in &path.root {
@@ -361,7 +365,11 @@ fn traverse_path<V: Visitor>(hir: &Map, visitor: &mut V, path: &Path) -> Result<
     traverse_path_segment(hir, visitor, &path.name)
 }
 
-fn traverse_path_segment<V: Visitor>(hir: &Map, visitor: &mut V, path: &PathSegment) -> Result<()> {
+fn traverse_path_segment<'hir, V: Visitor<'hir>>(
+    hir: &'hir Map,
+    visitor: &mut V,
+    path: &'hir PathSegment,
+) -> Result<()> {
     match path {
         PathSegment::Namespace { name } | PathSegment::Variant { name, .. } => {
             visitor.visit_identifier(name)?;

--- a/compiler/lume_infer/Cargo.toml
+++ b/compiler/lume_infer/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 lume_errors = { path = "../../crates/lume_errors" }
+lume_hash = { path = "../../crates/lume_hash" }
 lume_hir = { path = "../lume_hir" }
 lume_session = { path = "../lume_session" }
 lume_span = { path = "../../crates/lume_span" }

--- a/compiler/lume_infer/Cargo.toml
+++ b/compiler/lume_infer/Cargo.toml
@@ -19,6 +19,7 @@ error_snippet = { workspace = true }
 error_snippet_derive = { workspace = true }
 levenshtein = { version = "=1.0.5" }
 indexmap = { workspace = true }
+serde = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/compiler/lume_infer/src/instance.rs
+++ b/compiler/lume_infer/src/instance.rs
@@ -14,6 +14,17 @@ pub struct Instance {
 }
 
 impl Instance {
+    pub fn new(id: NodeId, generics: Generics) -> Self {
+        if generics.is_empty() {
+            return Instance::from(id);
+        }
+
+        Self {
+            id,
+            generics: Some(generics),
+        }
+    }
+
     #[inline]
     pub fn as_usize(&self) -> usize {
         lume_hash::portable_hash(self)

--- a/compiler/lume_infer/src/instance.rs
+++ b/compiler/lume_infer/src/instance.rs
@@ -1,0 +1,83 @@
+use lume_span::NodeId;
+use lume_types::TypeRef;
+use serde::{Deserialize, Serialize};
+
+use crate::TyInferCtx;
+
+#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
+pub struct Instance {
+    /// ID of the method or function which this instance represents.
+    pub id: NodeId,
+
+    /// Generic arguments for the callable instance
+    pub generics: Option<Generics>,
+}
+
+impl Instance {
+    pub fn display<'tcx>(&'tcx self, tcx: &'tcx TyInferCtx) -> InstanceDisplay<'tcx> {
+        InstanceDisplay(self, tcx)
+    }
+}
+
+impl From<NodeId> for Instance {
+    fn from(value: NodeId) -> Self {
+        Self {
+            id: value,
+            generics: None,
+        }
+    }
+}
+
+pub struct InstanceDisplay<'tcx>(&'tcx Instance, &'tcx TyInferCtx);
+
+impl std::fmt::Display for InstanceDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let InstanceDisplay(instance, tcx) = self;
+
+        write!(f, "{:+}", tcx.hir_path_of_node(instance.id))?;
+
+        if let Some(generics) = &instance.generics
+            && !generics.is_empty()
+        {
+            write!(
+                f,
+                "<{}>",
+                generics
+                    .iter()
+                    .filter_map(|(_id, generic)| tcx.ty_stringifier(generic).stringify().ok())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )?;
+        }
+
+        write!(f, "()")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Hash, Debug, Clone, PartialEq, Eq)]
+pub struct Generics {
+    /// Node IDs of the type parameters which are populated by [`Self::types`]
+    pub ids: Vec<NodeId>,
+
+    /// Type arguments for the matching type parameters.
+    pub types: Vec<TypeRef>,
+}
+
+impl Generics {
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        debug_assert_eq!(self.ids.len(), self.types.len());
+        self.ids.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (NodeId, &TypeRef)> {
+        self.ids.iter().copied().zip(self.types.iter())
+    }
+}

--- a/compiler/lume_infer/src/instance.rs
+++ b/compiler/lume_infer/src/instance.rs
@@ -50,8 +50,6 @@ impl std::fmt::Display for InstanceDisplay<'_> {
             )?;
         }
 
-        write!(f, "()")?;
-
         Ok(())
     }
 }

--- a/compiler/lume_infer/src/instance.rs
+++ b/compiler/lume_infer/src/instance.rs
@@ -14,6 +14,16 @@ pub struct Instance {
 }
 
 impl Instance {
+    #[inline]
+    pub fn as_usize(&self) -> usize {
+        lume_hash::portable_hash(self)
+    }
+
+    #[inline]
+    pub fn generics_or_empty(&self) -> &Generics {
+        self.generics.as_ref().unwrap_or(&EMPTY_GENERICS)
+    }
+
     pub fn display<'tcx>(&'tcx self, tcx: &'tcx TyInferCtx) -> InstanceDisplay<'tcx> {
         InstanceDisplay(self, tcx)
     }
@@ -62,6 +72,10 @@ pub struct Generics {
     /// Type arguments for the matching type parameters.
     pub types: Vec<TypeRef>,
 }
+pub static EMPTY_GENERICS: Generics = Generics {
+    ids: Vec::new(),
+    types: Vec::new(),
+};
 
 impl Generics {
     #[inline]

--- a/compiler/lume_infer/src/lib.rs
+++ b/compiler/lume_infer/src/lib.rs
@@ -13,9 +13,11 @@ use lume_types::{FunctionSig, TyCtx, TypeDatabaseContext, TypeRef};
 
 mod define;
 pub mod errors;
+pub mod instance;
 pub mod query;
 pub mod stringify;
 
+pub use instance::*;
 pub use stringify::*;
 
 #[cfg(test)]

--- a/compiler/lume_infer/src/lib.rs
+++ b/compiler/lume_infer/src/lib.rs
@@ -179,7 +179,7 @@ impl TyInferCtx {
     /// from the given definition.
     #[tracing::instrument(level = "DEBUG", skip_all, fields(ty = %ty.name, location = %ty.location, %def), err)]
     pub fn mk_type_ref_from(&self, ty: &lume_hir::Type, def: NodeId) -> Result<TypeRef> {
-        let type_parameters_id = self.available_type_params_at(def);
+        let type_parameters_id = self.all_type_parameters_of(def);
         let type_parameters = self.as_type_params(&type_parameters_id)?;
 
         self.mk_type_ref_generic(ty, &type_parameters)
@@ -196,7 +196,7 @@ impl TyInferCtx {
     /// available from the given definition.
     #[tracing::instrument(level = "DEBUG", skip_all, err)]
     pub fn mk_type_refs_from(&self, ty: &[lume_hir::Type], def: NodeId) -> Result<Vec<TypeRef>> {
-        let type_parameters_id = self.available_type_params_at(def);
+        let type_parameters_id = self.all_type_parameters_of(def);
         let type_parameters = self.as_type_params(&type_parameters_id)?;
 
         self.mk_type_refs_generic(ty, &type_parameters)
@@ -293,7 +293,7 @@ impl TyInferCtx {
     /// references to type IDs.
     #[tracing::instrument(level = "DEBUG", skip_all, err)]
     pub fn find_type_ref_from(&self, name: &Path, def: NodeId) -> Result<Option<TypeRef>> {
-        let type_parameters_id = self.available_type_params_at(def);
+        let type_parameters_id = self.all_type_parameters_of(def);
         let type_parameters = self.as_type_params(&type_parameters_id)?;
 
         self.find_type_ref_generic(name, &type_parameters)
@@ -358,7 +358,7 @@ impl TyInferCtx {
 
         // If `to` refers to a type parameter, check if `from` satisfies the
         // constraints.
-        if let Some(to_arg) = self.as_type_parameter(to)? {
+        if let Some(to_arg) = self.as_type_parameter(to.instance_of) {
             tracing::debug!("checking type parameter constraints: {from:?} => {to:?}");
 
             for constraint in &to_arg.constraints {

--- a/compiler/lume_infer/src/lib.rs
+++ b/compiler/lume_infer/src/lib.rs
@@ -7,6 +7,7 @@ use error_snippet::Result;
 use lume_architect::DatabaseContext;
 use lume_errors::{DiagCtx, Error};
 use lume_hir::{Path, TypeParameter};
+use lume_session::Package;
 use lume_span::*;
 use lume_types::{FunctionSig, TyCtx, TypeDatabaseContext, TypeRef};
 
@@ -93,6 +94,11 @@ impl TyInferCtx {
     /// Retrieves the diagnostics handler from the parent context.
     pub fn dcx(&self) -> DiagCtx {
         self.tcx.dcx()
+    }
+
+    /// Returns a reference to the current package.
+    pub fn current_package(&self) -> &Package {
+        self.package(self.hir().package).unwrap()
     }
 
     /// Defines all the different types, type parameters and type constraints

--- a/compiler/lume_infer/src/query/callable.rs
+++ b/compiler/lume_infer/src/query/callable.rs
@@ -1066,6 +1066,20 @@ impl TyInferCtx {
         !self.is_instanced_method(id)
     }
 
+    /// Attempts to find the function which is the entrypoint associated with
+    /// the current package.
+    #[tracing::instrument(level = "Trace", skip_all)]
+    pub fn entrypoint(&self) -> Option<&lume_hir::FunctionDefinition> {
+        let main_path = lume_hir::hir_func_path!(main);
+        let main_fn = self.probe_functions(&main_path).first()?.id;
+
+        let lume_hir::Node::Function(fn_def) = self.hir_node(main_fn)? else {
+            return None;
+        };
+
+        Some(fn_def)
+    }
+
     /// Determines whether the given function is an entrypoint.
     #[cached_query]
     #[tracing::instrument(level = "Trace", skip_all)]

--- a/compiler/lume_infer/src/query/callable.rs
+++ b/compiler/lume_infer/src/query/callable.rs
@@ -166,7 +166,7 @@ impl TyInferCtx {
     ///
     /// Methods returned by this method are not checked for validity within the
     /// current context, such as visibility, arguments or type arguments.
-    pub fn lookup_impl_methods_on(
+    fn lookup_impl_methods_on(
         &self,
         ty: &'_ lume_types::TypeRef,
         name: &'_ Identifier,
@@ -182,7 +182,7 @@ impl TyInferCtx {
     /// Methods returned by this method are not checked for validity within the
     /// current context, such as visibility, arguments or type arguments.
     #[tracing::instrument(level = "Trace", skip_all)]
-    pub fn lookup_trait_methods_on(
+    fn lookup_trait_methods_on(
         &self,
         ty: &'_ TypeRef,
         name: &'_ Identifier,
@@ -331,7 +331,7 @@ impl TyInferCtx {
     /// Methods returned by this method are not checked for validity within the
     /// current context, such as visibility, arguments or type arguments.
     #[tracing::instrument(level = "Trace", skip_all)]
-    pub fn lookup_method_suggestions(&self, ty: &lume_types::TypeRef, name: &Identifier) -> Vec<&'_ Method> {
+    fn lookup_method_suggestions(&self, ty: &lume_types::TypeRef, name: &Identifier) -> Vec<&'_ Method> {
         self.methods_defined_on(ty)
             .into_iter()
             .filter(|method| {
@@ -438,7 +438,7 @@ impl TyInferCtx {
     /// the current context, such as visibility, arguments or type
     /// arguments.
     #[tracing::instrument(level = "TRACE", skip_all, fields(%name))]
-    pub fn lookup_function_suggestions(&self, name: &Path) -> Vec<&'_ Function> {
+    fn lookup_function_suggestions(&self, name: &Path) -> Vec<&'_ Function> {
         self.tdb()
             .functions()
             .filter(|func| {
@@ -844,7 +844,7 @@ impl TyInferCtx {
     /// arguments defined on the callee of the exprssion, if any.
     #[tracing::instrument(level = "Trace", skip_all)]
     pub fn type_args_in_call(&self, expr: lume_hir::CallExpression) -> Result<Vec<TypeRef>> {
-        let type_parameters_id = self.available_type_params_at(expr.id());
+        let type_parameters_id = self.all_type_parameters_of(expr.id());
         let type_parameters = self.as_type_params(&type_parameters_id)?;
 
         match &expr {
@@ -880,14 +880,14 @@ impl TyInferCtx {
         param_type: &TypeRef,
         arg_type: &TypeRef,
     ) -> Result<Option<TypeRef>> {
-        if let Some(type_param_ref) = self.as_type_parameter(param_type)?
+        if let Some(type_param_ref) = self.as_type_parameter(param_type.instance_of)
             && type_param_ref.id == type_param_id
         {
             return Ok(Some(arg_type.to_owned()));
         }
 
         for (param_type_arg, arg_type_arg) in param_type.bound_types.iter().zip(arg_type.bound_types.iter()) {
-            if let Some(type_param_ref) = self.as_type_parameter(param_type_arg)?
+            if let Some(type_param_ref) = self.as_type_parameter(param_type_arg.instance_of)
                 && type_param_ref.id == type_param_id
             {
                 return Ok(Some(arg_type_arg.to_owned()));
@@ -970,7 +970,7 @@ impl TyInferCtx {
 
                 // Append all the type parameters which are available on the method,
                 // such as the type parameters on the implementation.
-                let mut all_type_params = self.available_type_params_at(method.id);
+                let mut all_type_params = self.all_type_parameters_of(method.id);
                 all_type_params.append(&mut signature.type_params);
 
                 signature.type_params = all_type_params;
@@ -1032,7 +1032,7 @@ impl TyInferCtx {
             .filter(move |m| m.callee.instance_of == self_ty.instance_of)
             .collect();
 
-        if let Some(type_param) = self.as_type_param(self_ty.instance_of) {
+        if let Some(type_param) = self.as_type_parameter(self_ty.instance_of) {
             for constraint in &type_param.constraints {
                 let Ok(constraint_ty) = self.mk_type_ref_from(constraint, self_ty.instance_of) else {
                     continue;

--- a/compiler/lume_infer/src/query/hir.rs
+++ b/compiler/lume_infer/src/query/hir.rs
@@ -302,6 +302,30 @@ impl TyInferCtx {
         None
     }
 
+    /// Returns a slice of all [`lume_hir::Field`]s on the `struct` definition
+    /// with the given ID.
+    ///
+    /// If the given ID does not refer to a struct definition, returns an empty
+    /// slice.
+    pub fn hir_fields_on(&self, id: NodeId) -> Result<&[lume_hir::Field]> {
+        let Some(Node::Type(lume_hir::TypeDefinition::Struct(struct_def))) = self.hir_node(id) else {
+            return Ok(&[]);
+        };
+
+        Ok(&struct_def.fields)
+    }
+
+    /// Returns the [`lume_hir::Field`] on the `struct` definition
+    /// with the given ID, which has the name `name`.
+    ///
+    /// If the given ID does not refer to a struct definition, returns an empty
+    /// slice. If no such field was found on the `struct` definition, returns
+    /// [`None`].
+    #[tracing::instrument(level = "Trace", skip_all)]
+    pub fn hir_field_on(&self, id: NodeId, name: &str) -> Result<Option<&lume_hir::Field>> {
+        Ok(self.hir_fields_on(id)?.iter().find(|field| field.name.as_str() == name))
+    }
+
     /// Attempts to get the body of the given [`NodeId`], if it contains a body.
     ///
     /// Otherwise, returns [`None`].
@@ -442,7 +466,7 @@ impl TyInferCtx {
                 };
 
                 let target_type = self.mk_type_ref_from(&implementation.target, owner)?;
-                let type_params = self.type_params_of(target_type.instance_of)?;
+                let type_params = self.type_parameters_of(target_type.instance_of)?;
 
                 Ok(type_params.get(param_idx).map(|ty| lume_hir::TypeId::from(*ty)))
             }
@@ -454,7 +478,7 @@ impl TyInferCtx {
                     .position(|ty| ty.id == type_parameter_id)
                 {
                     let target_type = self.mk_type_ref_from(&trait_impl.target, owner)?;
-                    let type_params = self.type_params_of(target_type.instance_of)?;
+                    let type_params = self.type_parameters_of(target_type.instance_of)?;
 
                     return Ok(type_params.get(param_idx).map(|ty| lume_hir::TypeId::from(*ty)));
                 }
@@ -466,7 +490,7 @@ impl TyInferCtx {
                     .position(|ty| ty.id == type_parameter_id)
                 {
                     let target_type = self.mk_type_ref_from(&trait_impl.name, owner)?;
-                    let type_params = self.type_params_of(target_type.instance_of)?;
+                    let type_params = self.type_parameters_of(target_type.instance_of)?;
 
                     return Ok(type_params.get(param_idx).map(|ty| lume_hir::TypeId::from(*ty)));
                 }

--- a/compiler/lume_infer/src/query/hir.rs
+++ b/compiler/lume_infer/src/query/hir.rs
@@ -437,14 +437,10 @@ impl TyInferCtx {
     /// Returns the canonical type parameter ID of the given type parameter.
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn hir_canonical_type_of(
-        &self,
-        type_parameter_id: lume_hir::TypeId,
-        owner: NodeId,
-    ) -> Result<Option<lume_hir::TypeId>> {
+    pub fn hir_canonical_type_of(&self, type_parameter_id: NodeId, owner: NodeId) -> Result<Option<lume_hir::TypeId>> {
         tracing::trace!(
             "{:+} => {:+}",
-            self.hir_path_of_node(type_parameter_id.as_node_id()),
+            self.hir_path_of_node(type_parameter_id),
             self.hir_path_of_node(owner),
         );
 
@@ -454,7 +450,7 @@ impl TyInferCtx {
                 | lume_hir::TypeDefinition::Enum(_)
                 | lume_hir::TypeDefinition::Trait(_),
             )
-            | Node::Function(_) => Ok(Some(type_parameter_id)),
+            | Node::Function(_) => Ok(Some(lume_hir::TypeId::from(type_parameter_id))),
             Node::Impl(implementation) => {
                 let Some(param_idx) = implementation
                     .target

--- a/compiler/lume_infer/src/query/lookup.rs
+++ b/compiler/lume_infer/src/query/lookup.rs
@@ -8,6 +8,7 @@ use crate::TyInferCtx;
 
 impl TyInferCtx {
     /// Gets the parent type of the given node.
+    #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, fields(%id), err, ret)]
     pub fn parent_type_of(&self, id: NodeId) -> Result<Option<TypeRef>> {
         for parent in self.hir_parent_iter(id) {
@@ -36,7 +37,7 @@ impl TyInferCtx {
     }
 
     /// Gets the parent type of the given field.
-    #[tracing::instrument(level = "Trace", skip_all)]
+    #[tracing::instrument(level = "TRACE", skip_all)]
     pub fn owning_struct_of_field(&self, field_id: NodeId) -> Result<&lume_hir::StructDefinition> {
         for parent in self.hir_parent_iter(field_id) {
             if let lume_hir::Node::Type(lume_hir::TypeDefinition::Struct(struct_def)) = parent {
@@ -53,7 +54,7 @@ impl TyInferCtx {
     /// Attempts to find the closest switch expression from the given
     /// definition.
     #[track_caller]
-    #[tracing::instrument(level = "Trace", skip_all)]
+    #[tracing::instrument(level = "TRACE", skip_all)]
     pub fn switch_expr_at(&self, source: NodeId) -> Option<&lume_hir::Switch> {
         for parent in self.hir_parent_iter(source) {
             let lume_hir::Node::Expression(expr) = parent else {
@@ -70,7 +71,7 @@ impl TyInferCtx {
 
     /// Attempts to find the closest loop from the given definition.
     #[track_caller]
-    #[tracing::instrument(level = "Trace", skip_all)]
+    #[tracing::instrument(level = "TRACE", skip_all)]
     pub fn loop_target_at(&self, source: NodeId) -> Option<&lume_hir::Statement> {
         for parent in self.hir_parent_iter(source) {
             let lume_hir::Node::Statement(stmt) = parent else {
@@ -85,51 +86,12 @@ impl TyInferCtx {
         None
     }
 
-    /// Returns the parameters available for the [`lume_hir::Node`] with the
-    /// given ID.
-    #[cached_query]
-    #[tracing::instrument(level = "Trace", skip_all)]
-    pub fn available_params_at(&self, def: NodeId) -> Vec<lume_hir::Parameter> {
-        let mut acc = Vec::new();
-
-        for parent in self.hir_parent_iter(def) {
-            let params = match parent {
-                lume_hir::Node::Function(func) => &func.signature.parameters,
-                lume_hir::Node::Method(method) => &method.signature.parameters,
-                lume_hir::Node::TraitMethodDef(method) => &method.signature.parameters,
-                lume_hir::Node::TraitMethodImpl(method) => &method.signature.parameters,
-                _ => continue,
-            };
-
-            acc.extend_from_slice(params);
-        }
-
-        acc
-    }
-
-    /// Returns all the type parameters available for the [`lume_hir::Node`]
-    /// with the given ID.
-    #[tracing::instrument(level = "Trace", skip_all)]
-    pub fn available_type_params_at(&self, def: NodeId) -> Vec<NodeId> {
-        let mut acc = Vec::new();
-
-        for parent in self.hir_parent_iter(def) {
-            let Ok(type_params) = self.type_params_of(parent.id()) else {
-                continue;
-            };
-
-            acc.extend_from_slice(type_params);
-        }
-
-        acc
-    }
-
     /// Determines whether the given node has any generic parameters within it's
     /// reach.
     #[tracing::instrument(level = "TRACE", skip_all, ret)]
     pub fn is_node_generic(&self, id: NodeId) -> bool {
         for parent in self.hir_parent_iter(id) {
-            let Ok(type_params) = self.type_params_of(parent.id()) else {
+            let Ok(type_params) = self.type_parameters_of(parent.id()) else {
                 continue;
             };
 
@@ -162,7 +124,7 @@ impl TyInferCtx {
     /// If no matching ancestor is found, returns [`Err`].
     #[tracing::instrument(level = "TRACE", skip_all, err)]
     pub fn return_type_within(&self, def: NodeId) -> Result<lume_types::TypeRef> {
-        let type_parameters_id = self.available_type_params_at(def);
+        let type_parameters_id = self.all_type_parameters_of(def);
         let type_parameters = self.as_type_params(&type_parameters_id)?;
 
         for parent in self.hir_parent_iter(def) {

--- a/compiler/lume_infer/src/query/lookup.rs
+++ b/compiler/lume_infer/src/query/lookup.rs
@@ -124,6 +124,23 @@ impl TyInferCtx {
         acc
     }
 
+    /// Determines whether the given node has any generic parameters within it's
+    /// reach.
+    #[tracing::instrument(level = "TRACE", skip_all, ret)]
+    pub fn is_node_generic(&self, id: NodeId) -> bool {
+        for parent in self.hir_parent_iter(id) {
+            let Ok(type_params) = self.type_params_of(parent.id()) else {
+                continue;
+            };
+
+            if !type_params.is_empty() {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Gets the return type of the [`lume_hir::Node`] with the given ID.
     #[tracing::instrument(level = "Trace", skip_all)]
     pub fn return_type_of(&self, id: NodeId) -> Option<&lume_hir::Type> {

--- a/compiler/lume_infer/src/query/mod.rs
+++ b/compiler/lume_infer/src/query/mod.rs
@@ -137,7 +137,7 @@ impl TyInferCtx {
                     return Err(self.missing_type_err(&e.path, e.path.location()));
                 };
 
-                let type_parameters = self.available_type_params_at(e.id);
+                let type_parameters = self.all_type_parameters_of(e.id);
 
                 let type_args = self.mk_type_refs_from(e.path.bound_types(), e.id)?;
                 let instantiated = self.instantiate_type_from(&ty_opt, &type_parameters, &type_args);
@@ -182,7 +182,7 @@ impl TyInferCtx {
             lume_hir::ExpressionKind::Member(expr) => {
                 let callee_type = self.type_of(expr.callee)?;
 
-                let Some(field) = self.field_on(callee_type.instance_of, &expr.name.name)? else {
+                let Some(field) = self.hir_field_on(callee_type.instance_of, &expr.name.name)? else {
                     let ty = self.tdb().type_(callee_type.instance_of).unwrap();
 
                     return Err(crate::errors::MissingField {
@@ -194,7 +194,7 @@ impl TyInferCtx {
                     .into());
                 };
 
-                let type_params = self.available_type_params_at(callee_type.instance_of);
+                let type_params = self.all_type_parameters_of(callee_type.instance_of);
                 let field_type = self.mk_type_ref_from(&field.field_type, callee_type.instance_of)?;
 
                 self.instantiate_type_from(&field_type, &type_params, &callee_type.bound_types)
@@ -394,7 +394,7 @@ impl TyInferCtx {
     /// [`lume_hir::If`] statement.
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn type_of_if_conditional(&self, cond: &lume_hir::If) -> Result<TypeRef> {
+    fn type_of_if_conditional(&self, cond: &lume_hir::If) -> Result<TypeRef> {
         let primary_case = cond.cases.first().unwrap();
 
         self.type_of_condition(primary_case)
@@ -403,7 +403,7 @@ impl TyInferCtx {
     /// Returns the *type* of the given [`lume_hir::Condition`].
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn type_of_condition(&self, cond: &lume_hir::Condition) -> Result<TypeRef> {
+    fn type_of_condition(&self, cond: &lume_hir::Condition) -> Result<TypeRef> {
         self.type_of_block(&cond.block)
     }
 
@@ -428,7 +428,7 @@ impl TyInferCtx {
     /// Returns the *type* of the given [`lume_hir::Return`].
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn type_of_return(&self, stmt: &lume_hir::Return) -> Result<TypeRef> {
+    fn type_of_return(&self, stmt: &lume_hir::Return) -> Result<TypeRef> {
         if let Some(expr) = stmt.value {
             self.type_of(expr)
         } else {
@@ -460,7 +460,7 @@ impl TyInferCtx {
     /// Returns the return type of the given [`lume_hir::CallExpression`].
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, fields(expr = %expr.name()), err, ret)]
-    pub fn type_of_call(&self, expr: lume_hir::CallExpression) -> Result<TypeRef> {
+    fn type_of_call(&self, expr: lume_hir::CallExpression) -> Result<TypeRef> {
         let callable = self.probe_callable(expr)?;
         let signature = self.instantiated_signature_of(callable, expr)?;
 
@@ -558,7 +558,7 @@ impl TyInferCtx {
     /// given name.
     #[cached_query(result)]
     #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn type_of_variant_field(&self, variant_name: &Path, field: usize) -> Result<TypeRef> {
+    fn type_of_variant_field(&self, variant_name: &Path, field: usize) -> Result<TypeRef> {
         let enum_def = self.enum_def_with_name(&variant_name.clone().parent().unwrap())?;
         let enum_case_def = self.enum_case_with_name(variant_name)?;
 
@@ -684,36 +684,6 @@ impl TyInferCtx {
             name: variant.clone(),
         }
         .into())
-    }
-
-    /// Returns the enum case definitions, which is being referred to by the
-    /// given expression.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Err`] if the no expression could be find with the given ID, or
-    /// if the expression type wasn't a reference to an enum definition.
-    #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn cases_of_enum_expr(&self, id: NodeId) -> Result<&[lume_hir::EnumDefinitionCase]> {
-        self.enum_cases_of(self.type_of(id)?.instance_of)
-    }
-
-    /// Returns the enum case definition, which is being referred to by the
-    /// given `Variant` expression.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if the given expression is not a `Variant`
-    /// expression.
-    #[tracing::instrument(level = "TRACE", skip_all, err)]
-    pub fn case_of_enum_expr(&self, id: NodeId) -> Result<&lume_hir::EnumDefinitionCase> {
-        let expr = self.hir_expect_expr(id);
-
-        if let lume_hir::ExpressionKind::Variant(var) = &expr.kind {
-            self.enum_case_with_name(&var.name)
-        } else {
-            panic!("bug!: attempted to find enum variant of non-variant expression")
-        }
     }
 
     /// Gets the case zero-indexed index of the variant within the given enum
@@ -1036,7 +1006,7 @@ impl TyInferCtx {
             return Ok(None);
         };
 
-        if let Some(type_field) = self.field_on(constructed_type.instance_of, &field.name.name)? {
+        if let Some(type_field) = self.hir_field_on(constructed_type.instance_of, &field.name.name)? {
             let field_type = self.mk_type_ref_from(&type_field.field_type, constructed_type.instance_of)?;
 
             return Ok(Some(field_type));
@@ -1206,30 +1176,6 @@ impl TyInferCtx {
             lume_hir::LiteralKind::Float(lit) => lit.kind.is_none(),
             _ => false,
         }
-    }
-
-    /// Returns a slice of all [`lume_hir::Field`]s on the `struct` definition
-    /// with the given ID.
-    ///
-    /// If the given ID does not refer to a struct definition, returns an empty
-    /// slice.
-    pub fn fields_on(&self, id: NodeId) -> Result<&[lume_hir::Field]> {
-        let Some(Node::Type(lume_hir::TypeDefinition::Struct(struct_def))) = self.hir_node(id) else {
-            return Ok(&[]);
-        };
-
-        Ok(&struct_def.fields)
-    }
-
-    /// Returns the [`lume_hir::Field`] on the `struct` definition
-    /// with the given ID, which has the name `name`.
-    ///
-    /// If the given ID does not refer to a struct definition, returns an empty
-    /// slice. If no such field was found on the `struct` definition, returns
-    /// [`None`].
-    #[tracing::instrument(level = "Trace", skip_all)]
-    pub fn field_on(&self, id: NodeId, name: &str) -> Result<Option<&lume_hir::Field>> {
-        Ok(self.fields_on(id)?.iter().find(|field| field.name.as_str() == name))
     }
 
     /// Determines whether unsafe code is allowed in the given package.

--- a/compiler/lume_infer/src/query/traits.rs
+++ b/compiler/lume_infer/src/query/traits.rs
@@ -49,7 +49,11 @@ impl TyInferCtx {
         #[cfg(debug_assertions)]
         self.hir_expect_trait(trait_id.instance_of);
 
-        if let Some(type_param) = self.as_type_parameter(ty)? {
+        if self.is_trait(ty) == Ok(true) && trait_id == ty {
+            return Ok(true);
+        }
+
+        if let Some(type_param) = self.as_type_parameter(ty.instance_of) {
             for constraint in &type_param.constraints {
                 let constraint_type = self.mk_type_ref_from(constraint, trait_id.instance_of)?;
 

--- a/compiler/lume_infer/src/query/ty.rs
+++ b/compiler/lume_infer/src/query/ty.rs
@@ -7,13 +7,25 @@ use lume_types::{TypeKind, TypeRef};
 use crate::TyInferCtx;
 
 impl TyInferCtx {
+    /// Returns the parameters for the [`lume_hir::Node`] with the given ID.
+    #[tracing::instrument(level = "TRACE", skip_all)]
+    pub fn parameters_of(&self, id: NodeId) -> &[lume_hir::Parameter] {
+        match self.hir_expect_node(id) {
+            lume_hir::Node::Function(func) => func.signature.parameters.as_slice(),
+            lume_hir::Node::Method(method) => method.signature.parameters.as_slice(),
+            lume_hir::Node::TraitMethodDef(method) => method.signature.parameters.as_slice(),
+            lume_hir::Node::TraitMethodImpl(method) => method.signature.parameters.as_slice(),
+            _ => &[],
+        }
+    }
+
     /// Gets a slice of the type parameters defined on the given node.
     ///
     /// # Errors
     ///
     /// If the given node is missing or cannot hold type parameters, [`Err`] is
     /// returned.
-    pub fn type_params_of(&self, id: NodeId) -> Result<&[NodeId]> {
+    pub fn type_parameters_of(&self, id: NodeId) -> Result<&[NodeId]> {
         let Some(node) = self.hir_node(id) else {
             return Ok(&[]);
         };
@@ -35,9 +47,51 @@ impl TyInferCtx {
         }
     }
 
+    /// Gets a vector of the type parameters defined on the given node, in
+    /// canonical form.
+    ///
+    /// # Errors
+    ///
+    /// If the given node is missing or cannot hold type parameters, [`Err`] is
+    /// returned.
+    pub fn canonical_type_parameters_of(&self, id: NodeId) -> Result<Vec<NodeId>> {
+        Ok(self
+            .type_parameters_of(id)?
+            .iter()
+            .map(|&type_parameter_id| {
+                let Some(owner) = self.hir_parent_node_of(id) else {
+                    return type_parameter_id;
+                };
+
+                match self.hir_canonical_type_of(TypeId::from(type_parameter_id), owner.id()) {
+                    Ok(Some(canonical)) => canonical.as_node_id(),
+                    _ => type_parameter_id,
+                }
+            })
+            .collect())
+    }
+
+    /// Returns all the type parameters available for the [`lume_hir::Node`]
+    /// with the given ID.
+    #[cached_query]
+    #[tracing::instrument(level = "TRACE", skip_all)]
+    pub fn all_type_parameters_of(&self, id: NodeId) -> Vec<NodeId> {
+        let mut acc = Vec::new();
+
+        for parent in self.hir_parent_iter(id) {
+            let Ok(type_params) = self.type_parameters_of(parent.id()) else {
+                continue;
+            };
+
+            acc.extend_from_slice(type_params);
+        }
+
+        acc
+    }
+
     /// Return the [`lume_hir::TypeParameter`], which correspond to the
     /// given ID, if it refers to a type parameter. Otherwise, returns [`None`].
-    pub fn as_type_param(&self, id: NodeId) -> Option<&lume_hir::TypeParameter> {
+    pub fn as_type_parameter(&self, id: NodeId) -> Option<&lume_hir::TypeParameter> {
         if let lume_hir::Node::Type(lume_hir::TypeDefinition::TypeParameter(type_param)) = self.hir_node(id)? {
             Some(type_param.as_ref())
         } else {
@@ -81,7 +135,7 @@ impl TyInferCtx {
 
     pub fn type_parameter_refs_of(&self, ty: &TypeRef) -> Result<Vec<TypeRef>> {
         Ok(if ty.bound_types.is_empty() {
-            self.type_params_of(ty.instance_of)?
+            self.type_parameters_of(ty.instance_of)?
                 .iter()
                 .map(|&param_id| TypeRef::new(param_id, self.hir_span_of_node(param_id)))
                 .collect()
@@ -117,18 +171,6 @@ impl TyInferCtx {
             self.tdb().type_(ty.instance_of).map(|t| t.kind),
             Some(TypeKind::TypeParameter)
         )
-    }
-
-    /// If the given [`TypeRef`] refers to a type parameter, returns a reference
-    /// to it's definition.
-    ///
-    /// Otherwise, returns [`None`].
-    #[tracing::instrument(level = "TRACE", skip_all, err, ret)]
-    pub fn as_type_parameter(&self, ty: &TypeRef) -> Result<Option<&lume_hir::TypeParameter>> {
-        match self.hir_expect_type(ty.instance_of) {
-            lume_hir::TypeDefinition::TypeParameter(type_param) => Ok(Some(type_param.as_ref())),
-            _ => Ok(None),
-        }
     }
 
     /// Determines whether the given [`TypeRef`] has any generic components.

--- a/compiler/lume_infer/src/query/ty.rs
+++ b/compiler/lume_infer/src/query/ty.rs
@@ -63,7 +63,7 @@ impl TyInferCtx {
                     return type_parameter_id;
                 };
 
-                match self.hir_canonical_type_of(TypeId::from(type_parameter_id), owner.id()) {
+                match self.hir_canonical_type_of(type_parameter_id, owner.id()) {
                     Ok(Some(canonical)) => canonical.as_node_id(),
                     _ => type_parameter_id,
                 }

--- a/compiler/lume_lsp/src/symbols/completions.rs
+++ b/compiler/lume_lsp/src/symbols/completions.rs
@@ -63,7 +63,7 @@ pub(crate) fn completions_at(engine: &Engine, ctx: CompletionContext) -> Option<
 }
 
 fn field_completions_of(package: &CheckedPackage, node: NodeId) -> impl Iterator<Item = lsp_types::CompletionItem> {
-    let fields_on_node = package.tcx.fields_on(node).unwrap_or_default();
+    let fields_on_node = package.tcx.hir_fields_on(node).unwrap_or_default();
 
     fields_on_node.iter().map(|field| {
         let field_name = field.name.to_string();

--- a/compiler/lume_lsp/src/symbols/definition.rs
+++ b/compiler/lume_lsp/src/symbols/definition.rs
@@ -57,7 +57,7 @@ pub(crate) fn definition_of(engine: &Engine, location: Location) -> Option<Locat
         }
         SymbolKind::Member { callee, field } => {
             let callee_type = package.tcx.type_of(*callee).ok()?;
-            let field = package.tcx.field_on(callee_type.instance_of, &field.name).ok()??;
+            let field = package.tcx.hir_field_on(callee_type.instance_of, &field.name).ok()??;
 
             Some(field.name.location)
         }

--- a/compiler/lume_lsp/src/symbols/hover.rs
+++ b/compiler/lume_lsp/src/symbols/hover.rs
@@ -136,7 +136,7 @@ pub(crate) fn hover_content_of_method(package: &CheckedPackage, method: &lume_ty
 
 pub(crate) fn hover_content_of_member(package: &CheckedPackage, callee: NodeId, field: &Identifier) -> Result<String> {
     let callee_type = package.tcx.type_of(callee)?;
-    let Some(field) = package.tcx.field_on(callee_type.instance_of, &field.name)? else {
+    let Some(field) = package.tcx.hir_field_on(callee_type.instance_of, &field.name)? else {
         return Ok(String::new());
     };
 

--- a/compiler/lume_lsp/src/symbols/lookup.rs
+++ b/compiler/lume_lsp/src/symbols/lookup.rs
@@ -133,7 +133,7 @@ struct LocationVisitor {
     symbols: IndexSet<SymbolEntry>,
 }
 
-impl Visitor for LocationVisitor {
+impl Visitor<'_> for LocationVisitor {
     fn visit_type(&mut self, ty: &lume_hir::Type) -> Result<()> {
         self.symbols.insert_sorted(SymbolEntry {
             kind: SymbolKind::Type { name: ty.name.clone() },

--- a/compiler/lume_mir/Cargo.toml
+++ b/compiler/lume_mir/Cargo.toml
@@ -9,6 +9,7 @@ test = false
 doctest = false
 
 [dependencies]
+lume_infer = { path = "../lume_infer" }
 lume_session = { path = "../lume_session" }
 lume_span = { path = "../../crates/lume_span" }
 lume_type_metadata = { path = "../lume_type_metadata" }

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -9,12 +9,13 @@ pub use fmt::*;
 use indexmap::{IndexMap, IndexSet};
 pub use lume_infer::instance::*;
 use lume_session::{Options, Package};
-use lume_span::{Interned, Location, NodeId, SourceFile};
-use lume_type_metadata::{StaticMetadata, TypeMetadata};
+use lume_span::{Internable, Interned, Location, NodeId, SourceFile};
+use lume_type_metadata::{StaticMetadata, TypeMetadata, TypeMetadataId};
 use lume_types::TypeRef;
 use serde::{Deserialize, Serialize};
 
 pub const POINTER_SIZE: usize = std::mem::size_of::<*const u32>();
+pub const POINTER_ALIGNMENT: usize = std::mem::align_of::<usize>();
 
 #[allow(clippy::cast_possible_truncation, reason = "infallible")]
 pub const POINTER_BITS: u8 = std::mem::size_of::<*const u32>() as u8 * 8;
@@ -219,7 +220,7 @@ pub enum ParameterKind {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Function {
     pub id: NodeId,
-    pub instance: Option<Instance>,
+    pub instance: Instance,
 
     pub name: Interned<String>,
     pub mangled_name: String,
@@ -241,7 +242,7 @@ impl Function {
     pub fn new(id: NodeId, name: Interned<String>, mangled_name: String, location: Location) -> Self {
         Function {
             id,
-            instance: None,
+            instance: Instance::from(id),
             name,
             mangled_name,
             registers: Registers::default(),

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod fmt;
+pub mod walk;
 
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -6,7 +7,7 @@ use std::hash::Hash;
 
 pub use fmt::*;
 use indexmap::{IndexMap, IndexSet};
-use lume_infer::TyInferCtx;
+pub use lume_infer::instance::*;
 use lume_session::{Options, Package};
 use lume_span::{Interned, Location, NodeId, SourceFile};
 use lume_type_metadata::{StaticMetadata, TypeMetadata};
@@ -48,6 +49,7 @@ impl ModuleMap {
     /// # Panics
     ///
     /// Panics if the given ID is invalid or out of bounds.
+    #[track_caller]
     pub fn function(&self, id: NodeId) -> &Function {
         self.functions.get(&Instance::from(id)).unwrap()
     }
@@ -57,6 +59,7 @@ impl ModuleMap {
     /// # Panics
     ///
     /// Panics if the given ID is invalid or out of bounds.
+    #[track_caller]
     pub fn function_mut(&mut self, id: NodeId) -> &mut Function {
         self.functions.get_mut(&Instance::from(id)).unwrap()
     }
@@ -66,6 +69,7 @@ impl ModuleMap {
     /// # Panics
     ///
     /// Panics if the given ID is invalid or out of bounds.
+    #[track_caller]
     pub fn instance(&self, instance: &Instance) -> &Function {
         self.functions.get(instance).unwrap()
     }
@@ -75,6 +79,7 @@ impl ModuleMap {
     /// # Panics
     ///
     /// Panics if the given ID is invalid or out of bounds.
+    #[track_caller]
     pub fn instance_mut(&'_ mut self, instance: &Instance) -> &'_ mut Function {
         self.functions.get_mut(instance).unwrap()
     }
@@ -121,84 +126,6 @@ impl std::fmt::Display for ModuleMap {
         }
 
         Ok(())
-    }
-}
-
-#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
-pub struct Instance {
-    /// ID of the method or function which this instance represents.
-    pub id: NodeId,
-
-    /// Generic arguments for the callable instance
-    pub generics: Option<Generics>,
-}
-
-impl Instance {
-    pub fn display<'tcx>(&'tcx self, tcx: &'tcx TyInferCtx) -> InstanceDisplay<'tcx> {
-        InstanceDisplay(self, tcx)
-    }
-}
-
-impl From<NodeId> for Instance {
-    fn from(value: NodeId) -> Self {
-        Self {
-            id: value,
-            generics: None,
-        }
-    }
-}
-
-pub struct InstanceDisplay<'tcx>(&'tcx Instance, &'tcx TyInferCtx);
-
-impl std::fmt::Display for InstanceDisplay<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let InstanceDisplay(instance, tcx) = self;
-
-        write!(f, "{:+}", tcx.hir_path_of_node(instance.id))?;
-
-        if let Some(generics) = &instance.generics
-            && !generics.is_empty()
-        {
-            write!(
-                f,
-                "<{}>",
-                generics
-                    .iter()
-                    .filter_map(|(_id, generic)| tcx.ty_stringifier(generic).stringify().ok())
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            )?;
-        }
-
-        write!(f, "()")?;
-
-        Ok(())
-    }
-}
-
-#[derive(Serialize, Deserialize, Default, Hash, Debug, Clone, PartialEq, Eq)]
-pub struct Generics {
-    /// Node IDs of the type parameters which are populated by [`Self::types`]
-    pub ids: Vec<NodeId>,
-
-    /// Type arguments for the matching type parameters.
-    pub types: Vec<TypeRef>,
-}
-
-impl Generics {
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.ids.is_empty()
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        debug_assert_eq!(self.ids.len(), self.types.len());
-        self.ids.len()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (NodeId, &TypeRef)> {
-        self.ids.iter().copied().zip(self.types.iter())
     }
 }
 
@@ -1415,9 +1342,10 @@ pub enum DeclarationKind {
 
     /// Represents a call to a function.
     Call {
-        func_id: NodeId,
+        instance: Instance,
         name: Interned<String>,
         args: Vec<Operand>,
+        type_args: Vec<TypeRef>,
     },
 
     /// Represents an indirect call to a function.

--- a/compiler/lume_mir/src/lib.rs
+++ b/compiler/lume_mir/src/lib.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 
 pub use fmt::*;
 use indexmap::{IndexMap, IndexSet};
+use lume_infer::TyInferCtx;
 use lume_session::{Options, Package};
 use lume_span::{Interned, Location, NodeId, SourceFile};
 use lume_type_metadata::{StaticMetadata, TypeMetadata};
@@ -27,7 +28,7 @@ pub struct ModuleMap {
 
     pub options: Options,
     pub metadata: StaticMetadata,
-    pub functions: IndexMap<NodeId, Function>,
+    pub functions: IndexMap<Instance, Function>,
 }
 
 impl ModuleMap {
@@ -48,7 +49,7 @@ impl ModuleMap {
     ///
     /// Panics if the given ID is invalid or out of bounds.
     pub fn function(&self, id: NodeId) -> &Function {
-        self.functions.get(&id).unwrap()
+        self.functions.get(&Instance::from(id)).unwrap()
     }
 
     /// Returns a mutable reference to the function with the given ID.
@@ -57,7 +58,25 @@ impl ModuleMap {
     ///
     /// Panics if the given ID is invalid or out of bounds.
     pub fn function_mut(&mut self, id: NodeId) -> &mut Function {
-        self.functions.get_mut(&id).unwrap()
+        self.functions.get_mut(&Instance::from(id)).unwrap()
+    }
+
+    /// Returns a reference to the function with the given instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given ID is invalid or out of bounds.
+    pub fn instance(&self, instance: &Instance) -> &Function {
+        self.functions.get(instance).unwrap()
+    }
+
+    /// Returns a mutable reference to the function with the given instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given ID is invalid or out of bounds.
+    pub fn instance_mut(&'_ mut self, instance: &Instance) -> &'_ mut Function {
+        self.functions.get_mut(instance).unwrap()
     }
 
     /// Returns a reference to the entrypoint function.
@@ -102,6 +121,84 @@ impl std::fmt::Display for ModuleMap {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
+pub struct Instance {
+    /// ID of the method or function which this instance represents.
+    pub id: NodeId,
+
+    /// Generic arguments for the callable instance
+    pub generics: Option<Generics>,
+}
+
+impl Instance {
+    pub fn display<'tcx>(&'tcx self, tcx: &'tcx TyInferCtx) -> InstanceDisplay<'tcx> {
+        InstanceDisplay(self, tcx)
+    }
+}
+
+impl From<NodeId> for Instance {
+    fn from(value: NodeId) -> Self {
+        Self {
+            id: value,
+            generics: None,
+        }
+    }
+}
+
+pub struct InstanceDisplay<'tcx>(&'tcx Instance, &'tcx TyInferCtx);
+
+impl std::fmt::Display for InstanceDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let InstanceDisplay(instance, tcx) = self;
+
+        write!(f, "{:+}", tcx.hir_path_of_node(instance.id))?;
+
+        if let Some(generics) = &instance.generics
+            && !generics.is_empty()
+        {
+            write!(
+                f,
+                "<{}>",
+                generics
+                    .iter()
+                    .filter_map(|(_id, generic)| tcx.ty_stringifier(generic).stringify().ok())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )?;
+        }
+
+        write!(f, "()")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Hash, Debug, Clone, PartialEq, Eq)]
+pub struct Generics {
+    /// Node IDs of the type parameters which are populated by [`Self::types`]
+    pub ids: Vec<NodeId>,
+
+    /// Type arguments for the matching type parameters.
+    pub types: Vec<TypeRef>,
+}
+
+impl Generics {
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        debug_assert_eq!(self.ids.len(), self.types.len());
+        self.ids.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (NodeId, &TypeRef)> {
+        self.ids.iter().copied().zip(self.types.iter())
     }
 }
 
@@ -195,6 +292,8 @@ pub enum ParameterKind {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Function {
     pub id: NodeId,
+    pub instance: Option<Instance>,
+
     pub name: Interned<String>,
     pub mangled_name: String,
     pub signature: Signature,
@@ -215,6 +314,7 @@ impl Function {
     pub fn new(id: NodeId, name: Interned<String>, mangled_name: String, location: Location) -> Self {
         Function {
             id,
+            instance: None,
             name,
             mangled_name,
             registers: Registers::default(),

--- a/compiler/lume_mir/src/walk.rs
+++ b/compiler/lume_mir/src/walk.rs
@@ -1,0 +1,236 @@
+pub use walk_mut::{VisitorMut, walk_mut};
+pub use walk_ref::{Visitor, walk};
+
+use crate::*;
+
+pub mod walk_ref {
+    use super::*;
+
+    /// Visitor trait for traversing a MIR function.
+    pub trait Visitor<'mir> {
+        fn visit_function(&mut self, _func: &'mir Function) {}
+
+        fn visit_block(&mut self, _func: &'mir Function, _block: &'mir BasicBlock) {}
+
+        fn visit_instruction(&mut self, _func: &'mir Function, _inst: &'mir Instruction) {}
+
+        fn visit_terminator(&mut self, _func: &'mir Function, _term: &'mir Terminator) {}
+
+        fn visit_declaration(&mut self, _func: &'mir Function, _decl: &'mir Declaration) {}
+
+        fn visit_operand(&mut self, _func: &'mir Function, _op: &'mir Operand) {}
+    }
+
+    /// Traverses the given MIR function using the provided visitor.
+    pub fn walk<'mir, V: Visitor<'mir>>(func: &'mir Function, visitor: &mut V) {
+        visitor.visit_function(func);
+
+        for block in func.blocks.values() {
+            traverse_block(func, visitor, block);
+        }
+    }
+
+    pub fn traverse_block<'mir, V: Visitor<'mir>>(func: &'mir Function, visitor: &mut V, block: &'mir BasicBlock) {
+        visitor.visit_block(func, block);
+
+        for inst in block.instructions.values() {
+            traverse_instruction(func, visitor, inst);
+        }
+
+        if let Some(term) = &block.terminator {
+            traverse_terminator(func, visitor, term);
+        }
+    }
+
+    fn traverse_instruction<'mir, V: Visitor<'mir>>(func: &'mir Function, visitor: &mut V, inst: &'mir Instruction) {
+        visitor.visit_instruction(func, inst);
+
+        match &inst.kind {
+            InstructionKind::Let { decl, .. } => {
+                traverse_declaration(func, visitor, decl);
+            }
+
+            InstructionKind::Store { value, .. }
+            | InstructionKind::StoreSlot { value, .. }
+            | InstructionKind::StoreField { value, .. } => {
+                visitor.visit_operand(func, value);
+            }
+
+            InstructionKind::Allocate { .. }
+            | InstructionKind::CreateSlot { .. }
+            | InstructionKind::ObjectRegister { .. } => {}
+        }
+    }
+
+    fn traverse_terminator<'mir, V: Visitor<'mir>>(func: &'mir Function, visitor: &mut V, term: &'mir Terminator) {
+        visitor.visit_terminator(func, term);
+
+        match &term.kind {
+            TerminatorKind::Return(operand) => {
+                if let Some(operand) = operand {
+                    visitor.visit_operand(func, operand);
+                }
+            }
+            TerminatorKind::ConditionalBranch {
+                then_block, else_block, ..
+            } => {
+                for arg in &then_block.arguments {
+                    visitor.visit_operand(func, arg);
+                }
+
+                for arg in &else_block.arguments {
+                    visitor.visit_operand(func, arg);
+                }
+            }
+            TerminatorKind::Switch { arms, fallback, .. } => {
+                for (_, arm) in arms {
+                    for arg in &arm.arguments {
+                        visitor.visit_operand(func, arg);
+                    }
+                }
+
+                for arg in &fallback.arguments {
+                    visitor.visit_operand(func, arg);
+                }
+            }
+            TerminatorKind::Branch(site) => {
+                for arg in &site.arguments {
+                    visitor.visit_operand(func, arg);
+                }
+            }
+            TerminatorKind::Unreachable => {}
+        }
+    }
+
+    fn traverse_declaration<'mir, V: Visitor<'mir>>(func: &'mir Function, visitor: &mut V, decl: &'mir Declaration) {
+        visitor.visit_declaration(func, decl);
+
+        match decl.kind.as_ref() {
+            DeclarationKind::Operand(operand) => visitor.visit_operand(func, operand),
+            DeclarationKind::Intrinsic { args, .. }
+            | DeclarationKind::Call { args, .. }
+            | DeclarationKind::IndirectCall { args, .. } => {
+                for arg in args {
+                    visitor.visit_operand(func, arg);
+                }
+            }
+            DeclarationKind::Cast { .. } => {}
+        }
+    }
+}
+
+pub mod walk_mut {
+    use super::*;
+
+    /// Visitor trait for traversing a MIR function.
+    pub trait VisitorMut {
+        fn visit_function(&mut self, _func: &mut Function) {}
+
+        fn visit_block(&mut self, _block: &mut BasicBlock) {}
+
+        fn visit_instruction(&mut self, _inst: &mut Instruction) {}
+
+        fn visit_terminator(&mut self, _term: &mut Terminator) {}
+
+        fn visit_declaration(&mut self, _decl: &mut Declaration) {}
+
+        fn visit_operand(&mut self, _op: &mut Operand) {}
+    }
+
+    /// Traverses the given MIR function using the provided visitor.
+    pub fn walk_mut<V: VisitorMut>(func: &mut Function, visitor: &mut V) {
+        visitor.visit_function(func);
+
+        for block in func.blocks.values_mut() {
+            traverse_block(visitor, block);
+        }
+    }
+
+    pub fn traverse_block<V: VisitorMut>(visitor: &mut V, block: &mut BasicBlock) {
+        visitor.visit_block(block);
+
+        for inst in block.instructions.values_mut() {
+            traverse_instruction(visitor, inst);
+        }
+
+        if let Some(term) = &mut block.terminator {
+            traverse_terminator(visitor, term);
+        }
+    }
+
+    fn traverse_instruction<V: VisitorMut>(visitor: &mut V, inst: &mut Instruction) {
+        visitor.visit_instruction(inst);
+
+        match &mut inst.kind {
+            InstructionKind::Let { decl, .. } => {
+                traverse_declaration(visitor, decl);
+            }
+
+            InstructionKind::Store { value, .. }
+            | InstructionKind::StoreSlot { value, .. }
+            | InstructionKind::StoreField { value, .. } => {
+                visitor.visit_operand(value);
+            }
+
+            InstructionKind::Allocate { .. }
+            | InstructionKind::CreateSlot { .. }
+            | InstructionKind::ObjectRegister { .. } => {}
+        }
+    }
+
+    fn traverse_terminator<V: VisitorMut>(visitor: &mut V, term: &mut Terminator) {
+        visitor.visit_terminator(term);
+
+        match &mut term.kind {
+            TerminatorKind::Return(operand) => {
+                if let Some(operand) = operand {
+                    visitor.visit_operand(operand);
+                }
+            }
+            TerminatorKind::ConditionalBranch {
+                then_block, else_block, ..
+            } => {
+                for arg in &mut then_block.arguments {
+                    visitor.visit_operand(arg);
+                }
+
+                for arg in &mut else_block.arguments {
+                    visitor.visit_operand(arg);
+                }
+            }
+            TerminatorKind::Switch { arms, fallback, .. } => {
+                for (_, arm) in arms {
+                    for arg in &mut arm.arguments {
+                        visitor.visit_operand(arg);
+                    }
+                }
+
+                for arg in &mut fallback.arguments {
+                    visitor.visit_operand(arg);
+                }
+            }
+            TerminatorKind::Branch(site) => {
+                for arg in &mut site.arguments {
+                    visitor.visit_operand(arg);
+                }
+            }
+            TerminatorKind::Unreachable => {}
+        }
+    }
+
+    fn traverse_declaration<V: VisitorMut>(visitor: &mut V, decl: &mut Declaration) {
+        visitor.visit_declaration(decl);
+
+        match decl.kind.as_mut() {
+            DeclarationKind::Operand(operand) => visitor.visit_operand(operand),
+            DeclarationKind::Intrinsic { args, .. }
+            | DeclarationKind::Call { args, .. }
+            | DeclarationKind::IndirectCall { args, .. } => {
+                for arg in args {
+                    visitor.visit_operand(arg);
+                }
+            }
+            DeclarationKind::Cast { .. } => {}
+        }
+    }
+}

--- a/compiler/lume_mir_lower/src/builder/decl.rs
+++ b/compiler/lume_mir_lower/src/builder/decl.rs
@@ -276,6 +276,8 @@ impl Builder<'_, '_> {
         let args = self.normalize_call_argumets(signature, args);
         let return_type = signature.return_type.clone();
 
+        tracing::debug!(%func_name, "call");
+
         self.declare_as(return_type, lume_mir::Declaration {
             kind: Box::new(lume_mir::DeclarationKind::Call {
                 instance,

--- a/compiler/lume_mir_lower/src/builder/decl.rs
+++ b/compiler/lume_mir_lower/src/builder/decl.rs
@@ -1,5 +1,5 @@
 use lume_mir::*;
-use lume_span::{Location, NodeId};
+use lume_span::Location;
 use lume_types::TypeRef;
 
 use crate::builder::Builder;
@@ -249,31 +249,39 @@ impl Builder<'_, '_> {
 
     /// Declares a new register with the returned value of calling the given
     /// function.
-    pub(crate) fn call(&mut self, func_id: NodeId, args: Vec<Operand>, location: Location) -> RegisterId {
-        let signature = &self.mcx.mir().function(func_id).signature;
+    pub(crate) fn call(
+        &mut self,
+        instance: Instance,
+        type_args: Vec<TypeRef>,
+        args: Vec<Operand>,
+        location: Location,
+    ) -> RegisterId {
+        let signature = &self.mcx.mir().instance(&instance).signature;
 
-        self.call_with_signature(func_id, signature, args, location)
+        self.call_with_signature(instance, signature, type_args, args, location)
     }
 
     /// Declares a new register with the returned value of calling the given
     /// function.
     pub(crate) fn call_with_signature(
         &mut self,
-        func_id: NodeId,
+        instance: Instance,
         signature: &Signature,
+        type_args: Vec<TypeRef>,
         args: Vec<Operand>,
         location: Location,
     ) -> RegisterId {
-        let func_name = self.mcx.mir().function(func_id).name;
+        let func_name = self.mcx.mir().instance(&instance).name;
 
         let args = self.normalize_call_argumets(signature, args);
         let return_type = signature.return_type.clone();
 
         self.declare_as(return_type, lume_mir::Declaration {
             kind: Box::new(lume_mir::DeclarationKind::Call {
-                func_id,
+                instance,
                 name: func_name,
                 args,
+                type_args,
             }),
             location,
         })
@@ -324,19 +332,19 @@ impl Builder<'_, '_> {
 
         let array_alloc_func_id = self.tcx().lang_item(lume_hir::LangItem::ArrayWithCapacity).unwrap();
         let array_alloc_func = self.mcx.function(array_alloc_func_id).unwrap();
+        let array_alloc_instance = Instance::from(array_alloc_func_id);
 
         let array_push_func_id = self.tcx().lang_item(lume_hir::LangItem::ArrayPush).unwrap();
+        let array_push_instance = Instance::from(array_push_func_id);
 
         let vararg_arr_reg = self
             .func
             .declare(array_alloc_func.signature.return_type.clone(), lume_mir::Declaration {
                 kind: Box::new(lume_mir::DeclarationKind::Call {
-                    func_id: array_alloc_func.id,
+                    instance: array_alloc_instance.clone(),
                     name: array_alloc_func.name,
-                    args: vec![
-                        lume_mir::Operand::integer(64, false, args.len().cast_signed() as i128),
-                        lume_mir::Operand::reference_of(metadata_reg),
-                    ],
+                    args: vec![lume_mir::Operand::integer(64, false, args.len().cast_signed() as i128)],
+                    type_args: vec![vararg_type.clone()],
                 }),
                 location: vararg_loc,
             });
@@ -347,7 +355,12 @@ impl Builder<'_, '_> {
             let vararg_arg = vararg_arr_op.clone();
             let metadata_op = lume_mir::Operand::reference_of(metadata_reg);
 
-            self.call(array_push_func_id, vec![vararg_arg, arg, metadata_op], vararg_loc);
+            self.call(
+                array_push_instance.clone(),
+                vec![vararg_type.clone()],
+                vec![vararg_arg, arg, metadata_op],
+                vararg_loc,
+            );
         }
 
         new_args.push(vararg_arr_op);

--- a/compiler/lume_mir_lower/src/builder/lower.rs
+++ b/compiler/lume_mir_lower/src/builder/lower.rs
@@ -284,7 +284,7 @@ fn bitcast(builder: &mut Builder<'_, '_>, expr: &lume_tir::Bitcast) -> lume_mir:
 fn construct(builder: &mut Builder<'_, '_>, expr: &lume_tir::Construct) -> lume_mir::Operand {
     builder.with_current_block(|builder, _| {
         let struct_name = builder.tcx().new_named_type(&expr.ty, true).unwrap();
-        let type_fields = builder.tcx().fields_on(expr.ty.instance_of).unwrap();
+        let type_fields = builder.tcx().hir_fields_on(expr.ty.instance_of).unwrap();
 
         // Sort all the constructor expressions so they have the same order as
         // the fields within the type. If this isn't done, the value of a field may be

--- a/compiler/lume_mir_lower/src/builder/lower.rs
+++ b/compiler/lume_mir_lower/src/builder/lower.rs
@@ -1,4 +1,4 @@
-use lume_mir::{BasicBlockId, Instance, RegisterId};
+use lume_mir::{BasicBlockId, RegisterId};
 use lume_span::Location;
 
 use crate::builder::Builder;
@@ -344,7 +344,10 @@ fn construct(builder: &mut Builder<'_, '_>, expr: &lume_tir::Construct) -> lume_
 fn call_expression(builder: &mut Builder<'_, '_>, expr: &lume_tir::Call) -> lume_mir::Operand {
     builder.with_current_block(|builder, _| {
         let is_ffi_call = builder.tcx().hir_is_callable_external(expr.function);
-        let call_instance = Instance::from(expr.function);
+        let call_instance =
+            builder
+                .mcx
+                .instantiated_instance(&builder.func.instance, expr.function, expr.type_arguments.clone());
 
         let mut signature = builder.signature_of(&call_instance);
         signature.return_type = builder.lower_type(&expr.return_type);

--- a/compiler/lume_mir_lower/src/builder/lower.rs
+++ b/compiler/lume_mir_lower/src/builder/lower.rs
@@ -1,4 +1,4 @@
-use lume_mir::{BasicBlockId, RegisterId};
+use lume_mir::{BasicBlockId, Instance, RegisterId};
 use lume_span::Location;
 
 use crate::builder::Builder;
@@ -344,8 +344,9 @@ fn construct(builder: &mut Builder<'_, '_>, expr: &lume_tir::Construct) -> lume_
 fn call_expression(builder: &mut Builder<'_, '_>, expr: &lume_tir::Call) -> lume_mir::Operand {
     builder.with_current_block(|builder, _| {
         let is_ffi_call = builder.tcx().hir_is_callable_external(expr.function);
+        let call_instance = Instance::from(expr.function);
 
-        let mut signature = builder.signature_of(expr.function);
+        let mut signature = builder.signature_of(&call_instance);
         signature.return_type = builder.lower_type(&expr.return_type);
 
         let return_type = expr.uninst_return_type.as_ref().unwrap_or(&expr.return_type);
@@ -385,7 +386,13 @@ fn call_expression(builder: &mut Builder<'_, '_>, expr: &lume_tir::Call) -> lume
             call_arguments.push(arg_operand);
         }
 
-        let return_value = builder.call_with_signature(expr.function, &signature, call_arguments, expr.location);
+        let return_value = builder.call_with_signature(
+            call_instance,
+            &signature,
+            expr.type_arguments.clone(),
+            call_arguments,
+            expr.location,
+        );
 
         builder.use_register(return_value, expr.location)
     })

--- a/compiler/lume_mir_lower/src/builder/mod.rs
+++ b/compiler/lume_mir_lower/src/builder/mod.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use lume_mir::*;
 use lume_mir_queries::MirQueryCtx;
-use lume_span::{Location, NodeId};
+use lume_span::Location;
 use lume_type_metadata::TypeMetadataId;
 use lume_typech::TyCheckCtx;
 use lume_types::TypeRef;
@@ -48,9 +48,10 @@ impl<'mir, 'tcx> Builder<'mir, 'tcx> {
         self.mcx.tcx()
     }
 
-    /// Gets the MIR function with the given ID.
-    pub(crate) fn function(&self, func_id: NodeId) -> &Function {
-        self.mcx.mir().function(func_id)
+    /// Gets the MIR function with the given instance.
+    #[track_caller]
+    pub(crate) fn instance(&self, instance: &Instance) -> &Function {
+        self.mcx.mir().instance(instance)
     }
 
     /// Creates a new block in the function.

--- a/compiler/lume_mir_lower/src/builder/mod.rs
+++ b/compiler/lume_mir_lower/src/builder/mod.rs
@@ -120,7 +120,7 @@ impl Builder<'_, '_> {
     pub(crate) fn declare_var(&mut self, block: BasicBlockId, variable: lume_tir::VariableId, register: RegisterId) {
         let variable = lume_mir::VariableId(variable.0);
 
-        tracing::debug!("[{}] declaring {variable} in {block}.{register}", self.func.name);
+        tracing::debug!("declaring {variable} in {block}.{register}");
 
         self.func.variables.define(block, register, variable);
     }
@@ -130,7 +130,7 @@ impl Builder<'_, '_> {
         let block = self.func.current_block().id;
         let var = lume_mir::VariableId(var.0);
 
-        tracing::debug!("[{}] referencing {var} in {block}", self.func.name);
+        tracing::debug!("referencing {var} in {block}");
 
         self.func.variables.reference(block, var)
     }
@@ -235,6 +235,8 @@ impl Builder<'_, '_> {
         if !self.func.current_block().has_terminator() {
             self.add_edge_from_current(block);
         }
+
+        tracing::debug!(%block, "branch_to");
 
         self.func.current_block_mut().branch(block, location);
     }

--- a/compiler/lume_mir_lower/src/builder/ty.rs
+++ b/compiler/lume_mir_lower/src/builder/ty.rs
@@ -1,4 +1,4 @@
-use lume_span::NodeId;
+use lume_mir::Instance;
 use lume_types::TypeRef;
 
 use crate::builder::Builder;
@@ -82,19 +82,19 @@ impl Builder<'_, '_> {
 
                 lume_mir::Type::integer(*bits, signed)
             }
-            lume_mir::DeclarationKind::Call { func_id, .. } => self.function_ret_type(*func_id),
+            lume_mir::DeclarationKind::Call { instance, .. } => self.function_ret_type(instance),
             lume_mir::DeclarationKind::IndirectCall { signature, .. } => signature.return_type.clone(),
         }
     }
 
     /// Gets the MIR signature of the function with the given ID.
-    pub(crate) fn signature_of(&self, func_id: NodeId) -> lume_mir::Signature {
-        self.function(func_id).signature.clone()
+    pub(crate) fn signature_of(&self, instance: &Instance) -> lume_mir::Signature {
+        self.instance(instance).signature.clone()
     }
 
     /// Gets the MIR return type of the function with the given ID.
-    pub(crate) fn function_ret_type(&self, func_id: NodeId) -> lume_mir::Type {
-        self.signature_of(func_id).return_type.clone()
+    pub(crate) fn function_ret_type(&self, instance: &Instance) -> lume_mir::Type {
+        self.signature_of(instance).return_type.clone()
     }
 
     /// Creates a MIR union type from the given enum type.

--- a/compiler/lume_mir_lower/src/dynamic/mod.rs
+++ b/compiler/lume_mir_lower/src/dynamic/mod.rs
@@ -1,4 +1,4 @@
-use lume_mir::{RegisterId, Signature};
+use lume_mir::{Instance, RegisterId, Signature};
 use lume_span::{Location, NodeId};
 
 use crate::builder::Builder;
@@ -38,7 +38,7 @@ impl<'shim, 'mir, 'tcx> DynamicShimBuilder<'shim, 'mir, 'tcx> {
     /// Returns the signature of the target function.
     fn target_signature(&self) -> Signature {
         let mut signature = self.signature.clone();
-        signature.return_type = self.builder.function_ret_type(self.function.id);
+        signature.return_type = self.builder.function_ret_type(&Instance::from(self.function.id));
 
         signature
     }
@@ -61,7 +61,12 @@ impl<'shim, 'mir, 'tcx> DynamicShimBuilder<'shim, 'mir, 'tcx> {
             let method_id_arg = lume_mir::Operand::integer(64, false, method_id.as_usize().cast_signed() as i128);
             let metadata_arg = lume_mir::Operand::reference_of(type_metadata_reg);
 
-            let method_ptr = builder.call(lookup_method_id, vec![method_id_arg, metadata_arg], Location::empty());
+            let method_ptr = builder.call(
+                Instance::from(lookup_method_id),
+                vec![],
+                vec![method_id_arg, metadata_arg],
+                Location::empty(),
+            );
             let null_cmp = builder.ieq_imm(lume_mir::Operand::reference_of(method_ptr), 0, 64, false);
 
             let found_block_args = [&[method_ptr][..], &self.parameters[..]].concat();

--- a/compiler/lume_mir_lower/src/dynamic/mod.rs
+++ b/compiler/lume_mir_lower/src/dynamic/mod.rs
@@ -38,7 +38,7 @@ impl<'shim, 'mir, 'tcx> DynamicShimBuilder<'shim, 'mir, 'tcx> {
     /// Returns the signature of the target function.
     fn target_signature(&self) -> Signature {
         let mut signature = self.signature.clone();
-        signature.return_type = self.builder.function_ret_type(&Instance::from(self.function.id));
+        signature.return_type = self.builder.lower_type(&self.function.return_type);
 
         signature
     }

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -3,7 +3,6 @@ pub(crate) mod dynamic;
 pub(crate) mod pass;
 pub(crate) mod ty;
 
-use indexmap::IndexMap;
 use lume_mir::{Function, ModuleMap};
 use lume_mir_queries::MirQueryCtx;
 use lume_session::{Options, Package};
@@ -41,7 +40,8 @@ impl<'tcx> ModuleTransformer<'tcx> {
             let signature = self.signature_of(func);
 
             let mangle_version = lume_mangle::Version::default();
-            let mangled_name = lume_mangle::mangled(self.mcx.tcx(), func.id, mangle_version).unwrap();
+            let mangle_instance = lume_mangle::Instance::from(func.id);
+            let mangled_name = lume_mangle::mangled(self.mcx.tcx(), &mangle_instance, mangle_version).unwrap();
 
             let mut func = Function::new(func.id, func.name_as_str().intern(), mangled_name, func.location);
             func.signature = signature;
@@ -63,31 +63,7 @@ impl<'tcx> ModuleTransformer<'tcx> {
             self.mcx.mir_mut().functions.insert(instance, defined_func);
         }
 
-        let mono_items = lume_mono::collect(&self.mcx).unwrap();
-
-        for tir_func in functions {
-            if !mono_items.any_of(tir_func.id) {
-                continue;
-            }
-
-            let base_instance = lume_mir::Instance::from(tir_func.id);
-            let base_mir_func = self.mcx.mir().instance(&base_instance);
-            let mut mono_functions = IndexMap::new();
-
-            for instance in mono_items.all_of(tir_func.id) {
-                let Some(canon_mir_func) = lume_mono::canonicalize(&self.mcx, base_mir_func, instance) else {
-                    tracing::debug!("skipping canonicalization for {}", instance.display(self.mcx.tcx()));
-                    continue;
-                };
-
-                mono_functions.insert(instance.to_owned(), canon_mir_func);
-            }
-
-            if !mono_functions.is_empty() {
-                self.mcx.mir_mut().functions.shift_remove(&base_instance);
-                self.mcx.mir_mut().functions.extend(mono_functions);
-            }
-        }
+        lume_mono::canonicalize(&mut self.mcx);
 
         self.mcx.take_mir()
     }

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod dynamic;
 pub(crate) mod pass;
 pub(crate) mod ty;
 
+use indexmap::IndexMap;
 use lume_mir::{Function, ModuleMap};
 use lume_mir_queries::MirQueryCtx;
 use lume_session::{Options, Package};
@@ -36,6 +37,7 @@ impl<'tcx> ModuleTransformer<'tcx> {
         // This ensures that any functions called *before* they are defined
         // within the source file still resolve correctly.
         for func in functions {
+            let instance = lume_mir::Instance::from(func.id);
             let signature = self.signature_of(func);
 
             let mangle_version = lume_mangle::Version::default();
@@ -49,18 +51,43 @@ impl<'tcx> ModuleTransformer<'tcx> {
                 func.registers.allocate_param(parameter.ty.clone());
             }
 
-            self.mcx.mir_mut().functions.insert(func.id, func);
+            self.mcx.mir_mut().functions.insert(instance, func);
         }
 
         for func in functions {
-            let func_decl = self.mcx.mir().functions.get(&func.id).unwrap().clone();
+            let instance = lume_mir::Instance::from(func.id);
+            let func_decl = self.mcx.mir().functions.get(&instance).unwrap().clone();
             let builder = builder::Builder::create_from(&self.mcx, func_decl);
 
             let defined_func = builder::lower::lower_function(builder, func);
-            self.mcx.mir_mut().functions.insert(func.id, defined_func);
+            self.mcx.mir_mut().functions.insert(instance, defined_func);
         }
 
-        let _mono_items = lume_mono::collect(&self.mcx).unwrap();
+        let mono_items = lume_mono::collect(&self.mcx).unwrap();
+
+        for tir_func in functions {
+            if !mono_items.any_of(tir_func.id) {
+                continue;
+            }
+
+            let base_instance = lume_mir::Instance::from(tir_func.id);
+            let base_mir_func = self.mcx.mir().instance(&base_instance);
+            let mut mono_functions = IndexMap::new();
+
+            for instance in mono_items.all_of(tir_func.id) {
+                let Some(canon_mir_func) = lume_mono::canonicalize(&self.mcx, base_mir_func, instance) else {
+                    tracing::debug!("skipping canonicalization for {}", instance.display(self.mcx.tcx()));
+                    continue;
+                };
+
+                mono_functions.insert(instance.to_owned(), canon_mir_func);
+            }
+
+            if !mono_functions.is_empty() {
+                self.mcx.mir_mut().functions.shift_remove(&base_instance);
+                self.mcx.mir_mut().functions.extend(mono_functions);
+            }
+        }
 
         self.mcx.take_mir()
     }

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -60,6 +60,8 @@ impl<'tcx> ModuleTransformer<'tcx> {
             self.mcx.mir_mut().functions.insert(func.id, defined_func);
         }
 
+        let _mono_items = lume_mono::collect(&self.mcx).unwrap();
+
         self.mcx.take_mir()
     }
 

--- a/compiler/lume_mir_lower/src/lib.rs
+++ b/compiler/lume_mir_lower/src/lib.rs
@@ -37,33 +37,39 @@ impl<'tcx> ModuleTransformer<'tcx> {
         // within the source file still resolve correctly.
         for func in functions {
             let instance = lume_mir::Instance::from(func.id);
-            let signature = self.signature_of(func);
 
-            let mangle_version = lume_mangle::Version::default();
-            let mangle_instance = lume_mangle::Instance::from(func.id);
-            let mangled_name = lume_mangle::mangled(self.mcx.tcx(), &mangle_instance, mangle_version).unwrap();
+            tracing::debug_span!("declare_function", instance = %instance.display(self.mcx.tcx())).in_scope(|| {
+                let signature = self.signature_of(func);
 
-            let mut func = Function::new(func.id, func.name_as_str().intern(), mangled_name, func.location);
-            func.signature = signature;
+                let mangle_version = lume_mangle::Version::default();
+                let mangle_instance = lume_mangle::Instance::from(func.id);
+                let mangled_name = lume_mangle::mangled(self.mcx.tcx(), &mangle_instance, mangle_version).unwrap();
 
-            // Offset the register counter by the number of parameters.
-            for parameter in &func.signature.parameters {
-                func.registers.allocate_param(parameter.ty.clone());
-            }
+                let mut func = Function::new(func.id, func.name_as_str().intern(), mangled_name, func.location);
+                func.signature = signature;
 
-            self.mcx.mir_mut().functions.insert(instance, func);
+                // Offset the register counter by the number of parameters.
+                for parameter in &func.signature.parameters {
+                    func.registers.allocate_param(parameter.ty.clone());
+                }
+
+                self.mcx.mir_mut().functions.insert(instance, func);
+            });
         }
+
+        let mono_items = lume_mono::canonicalize(&mut self.mcx);
 
         for func in functions {
-            let instance = lume_mir::Instance::from(func.id);
-            let func_decl = self.mcx.mir().functions.get(&instance).unwrap().clone();
-            let builder = builder::Builder::create_from(&self.mcx, func_decl);
+            for instance in mono_items.all_of(func.id) {
+                tracing::debug_span!("lowering_mono", instance = %instance.display(self.mcx.tcx())).in_scope(|| {
+                    let func_decl = self.mcx.mir().functions.get(instance).unwrap().clone();
+                    let builder = builder::Builder::create_from(&self.mcx, func_decl);
 
-            let defined_func = builder::lower::lower_function(builder, func);
-            self.mcx.mir_mut().functions.insert(instance, defined_func);
+                    let defined_func = builder::lower::lower_function(builder, func);
+                    self.mcx.mir_mut().functions.insert(instance.clone(), defined_func);
+                });
+            }
         }
-
-        lume_mono::canonicalize(&mut self.mcx);
 
         self.mcx.take_mir()
     }

--- a/compiler/lume_mir_lower/src/ty.rs
+++ b/compiler/lume_mir_lower/src/ty.rs
@@ -26,7 +26,7 @@ pub(crate) fn lower_type(mcx: &MirQueryCtx, type_ref: &TypeRef) -> lume_mir::Typ
             let struct_def = mcx.tcx().hir_expect_struct(type_ref.instance_of);
             let name = format!("{:+}", struct_def.name);
 
-            let ty_props = mcx.tcx().fields_on(type_ref.instance_of).unwrap();
+            let ty_props = mcx.tcx().hir_fields_on(type_ref.instance_of).unwrap();
             let props = ty_props
                 .iter()
                 .map(|prop| {

--- a/compiler/lume_mir_opt/src/lib.rs
+++ b/compiler/lume_mir_opt/src/lib.rs
@@ -2,7 +2,6 @@ pub(crate) mod pass;
 
 use lume_mir::ModuleMap;
 use lume_mir_queries::MirQueryCtx;
-use lume_span::NodeId;
 use lume_typech::TyCheckCtx;
 
 pub struct Optimizer<'tcx> {
@@ -37,11 +36,17 @@ impl<'tcx> Optimizer<'tcx> {
         let functions = self.mcx.mir().functions.iter();
 
         let eligible_functions = functions
-            .filter_map(|(id, func)| if is_func_eligible(func) { Some(*id) } else { None })
-            .collect::<Vec<NodeId>>();
+            .filter_map(|(instance, func)| {
+                if is_func_eligible(func) {
+                    Some(instance.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
-        for func_id in eligible_functions {
-            pass::run_all_passes(&mut self.mcx, func_id);
+        for instance in eligible_functions {
+            pass::run_all_passes(&mut self.mcx, &instance);
         }
     }
 }

--- a/compiler/lume_mir_opt/src/pass.rs
+++ b/compiler/lume_mir_opt/src/pass.rs
@@ -3,7 +3,6 @@ mod heap_to_stack;
 use lume_mir::*;
 use lume_mir_queries::MirQueryCtx;
 use lume_session::OptimizationLevel;
-use lume_span::NodeId;
 
 /// Defines a MIR optimization pass which can be executed over a function or
 /// block.
@@ -15,31 +14,31 @@ pub(crate) trait OptimizerPass {
     fn enabled(level: OptimizationLevel) -> bool;
 
     /// Executes the pass on the given function.
-    fn execute(&mut self, mcx: &mut MirQueryCtx, func_id: NodeId);
+    fn execute(&mut self, mcx: &mut MirQueryCtx, instance: &Instance);
 }
 
 /// Executes the given optimizer pass on the given function, if the pass is
 /// enabled under the optimization level.
 #[inline]
-pub(crate) fn run_pass<P: OptimizerPass>(mcx: &mut MirQueryCtx, level: OptimizationLevel, func_id: NodeId) {
+pub(crate) fn run_pass<P: OptimizerPass>(mcx: &mut MirQueryCtx, level: OptimizationLevel, instance: &Instance) {
     if P::enabled(level) {
         let mut pass = P::new();
-        pass.execute(mcx, func_id);
+        pass.execute(mcx, instance);
     }
 }
 
 /// Attempts to run all optimization passes which have been enabled by `level`
 /// on the given function.
 #[inline]
-pub(crate) fn run_all_passes(mcx: &mut MirQueryCtx, func_id: NodeId) {
+pub(crate) fn run_all_passes(mcx: &mut MirQueryCtx, instance: &Instance) {
     let session = &mcx.gcx().session;
     let level = session.options.optimize;
 
-    run_pass::<heap_to_stack::HeapToStack>(mcx, level, func_id);
+    run_pass::<heap_to_stack::HeapToStack>(mcx, level, instance);
 
     // If the `dump_mir` property is defined but empty, we dump the function MIR
     // after all the passes have been executed.
-    let func = mcx.mir().function(func_id);
+    let func = mcx.mir().instance(instance);
 
     #[allow(clippy::disallowed_macros, reason = "only used in debugging")]
     if mcx.should_dump_func(func, None) {

--- a/compiler/lume_mir_opt/src/pass/heap_to_stack.rs
+++ b/compiler/lume_mir_opt/src/pass/heap_to_stack.rs
@@ -23,11 +23,11 @@ impl OptimizerPass for HeapToStack {
         level.speed_level() >= 2
     }
 
-    #[tracing::instrument(level = "DEBUG", skip_all, fields(name = %mcx.mir().function(func_id).name))]
-    fn execute(&mut self, mcx: &mut MirQueryCtx, func_id: NodeId) {
+    #[tracing::instrument(level = "DEBUG", skip_all, fields(name = %mcx.mir().instance(instance).name))]
+    fn execute(&mut self, mcx: &mut MirQueryCtx, instance: &Instance) {
         let mut replacements = Vec::new();
 
-        let func = mcx.mir().function(func_id);
+        let func = mcx.mir().instance(instance);
 
         for block in func.blocks.values() {
             for (&idx, inst) in &block.instructions {
@@ -43,7 +43,7 @@ impl OptimizerPass for HeapToStack {
             }
         }
 
-        let func = mcx.mir_mut().function_mut(func_id);
+        let func = mcx.mir_mut().instance_mut(instance);
 
         let mut slot_updates = Vec::new();
 
@@ -65,7 +65,7 @@ impl OptimizerPass for HeapToStack {
         }
 
         for (block_id, register, slot, offset) in slot_updates {
-            replace_reg_with_slot(mcx, func_id, block_id, register, slot, offset);
+            replace_reg_with_slot(mcx, instance, block_id, register, slot, offset);
         }
     }
 }
@@ -74,13 +74,13 @@ impl OptimizerPass for HeapToStack {
 /// instructions which utilize the slot `slot`.
 fn replace_reg_with_slot(
     mcx: &mut MirQueryCtx,
-    func_id: NodeId,
+    instance: &Instance,
     block_id: BasicBlockId,
     register: RegisterId,
     slot: SlotId,
     after: InstructionId,
 ) {
-    let func = mcx.mir_mut().function_mut(func_id);
+    let func = mcx.mir_mut().instance_mut(instance);
     let block = func.block_mut(block_id);
 
     let offset = block.instructions.get_index_of(&after).unwrap_or(0);

--- a/compiler/lume_mir_queries/Cargo.toml
+++ b/compiler/lume_mir_queries/Cargo.toml
@@ -12,6 +12,7 @@ lume_mir = { path = "../lume_mir" }
 lume_session = { path = "../lume_session" }
 lume_span = { path = "../../crates/lume_span" }
 lume_typech = { path = "../lume_typech" }
+lume_types = { path = "../lume_types" }
 
 indexmap = { workspace = true }
 lume_architect = { workspace = true }

--- a/compiler/lume_mir_queries/src/analysis/mod.rs
+++ b/compiler/lume_mir_queries/src/analysis/mod.rs
@@ -105,14 +105,14 @@ impl MirQueryCtx<'_> {
                         }
                     }
                     DeclarationKind::Call {
-                        func_id: callee_id,
+                        instance: callee_instance,
                         args,
                         ..
                     } => {
                         for (idx, arg) in args.iter().enumerate() {
                             if arg.stores_register(reg) {
                                 let param = RegisterId::new(idx);
-                                let callee = self.mir().function(*callee_id);
+                                let callee = self.mir().instance(callee_instance);
 
                                 self.does_register_escape_inner(callee, BasicBlockId(0), param, call_stack)?;
                             }

--- a/compiler/lume_mir_queries/src/instance.rs
+++ b/compiler/lume_mir_queries/src/instance.rs
@@ -1,4 +1,4 @@
-use lume_mir::Instance;
+use lume_mir::{Generics, Instance};
 use lume_span::NodeId;
 use lume_types::TypeRef;
 
@@ -6,17 +6,17 @@ use crate::MirQueryCtx;
 
 impl MirQueryCtx<'_> {
     #[inline]
-    pub fn instance_of(&self, id: NodeId, type_arguments: Vec<TypeRef>) -> lume_mir::Instance {
+    pub fn instance_of(&self, id: NodeId, type_arguments: Vec<TypeRef>) -> Instance {
         let type_parameter_ids = self.tcx().all_type_parameters_of(id);
         // debug_assert_eq!(type_parameter_ids.len(), type_arguments.len());
 
         if type_arguments.is_empty() {
-            return lume_mir::Instance { id, generics: None };
+            return Instance { id, generics: None };
         }
 
-        lume_mir::Instance {
+        Instance {
             id,
-            generics: Some(lume_mir::Generics {
+            generics: Some(Generics {
                 ids: type_parameter_ids,
                 types: type_arguments,
             }),
@@ -24,7 +24,7 @@ impl MirQueryCtx<'_> {
     }
 
     #[inline]
-    pub fn instance_of_type(&self, ty: TypeRef) -> lume_mir::Instance {
+    pub fn instance_of_type(&self, ty: TypeRef) -> Instance {
         self.instance_of(ty.instance_of, ty.bound_types)
     }
 
@@ -65,5 +65,75 @@ impl MirQueryCtx<'_> {
         }
 
         instance
+    }
+
+    /// Attempts to instantiate a new [`TypeRef`] from a set of generic
+    /// arguments.
+    ///
+    /// **Arguments**:
+    /// - `type_ref`: type reference to instantiate.
+    /// - `generics`: any type arguments supplied for the type. Could be the
+    ///   generics from a call site or supplied by the user.
+    ///
+    /// # Example
+    ///
+    /// Let's say we want to instantiat the type of `value`:
+    /// ```lm (ignore,illustration)
+    /// fn foo() {
+    ///   let value = bar<T, UInt32>();
+    /// }
+    /// ```
+    /// would result in the arguments of:
+    /// - `type_ref = type_of(value)`
+    /// - `generics = [T, UInt32])`
+    pub fn instantiated_type(&self, mut type_ref: TypeRef, generics: &Generics) -> TypeRef {
+        // Replace all contained type parameters with their respective canonical type
+        // parameter. This helps with mapping the correct type arguments into the
+        // type-ref, as they might not use the same type parameter IDs.
+        for bound_type in type_ref.walk_mut() {
+            if !bound_type.bound_types.is_empty() || !self.tcx().is_type_parameter(bound_type) {
+                continue;
+            }
+
+            let Some(owner) = self.tcx().hir_parent_node_of(bound_type.instance_of) else {
+                continue;
+            };
+
+            if let Ok(Some(canonical)) = self.tcx().hir_canonical_type_of(bound_type.instance_of, owner.id()) {
+                bound_type.instance_of = canonical.as_node_id();
+            }
+        }
+
+        for (type_parameter_id, replacement) in generics.iter() {
+            type_ref.replace_contained(type_parameter_id, replacement);
+        }
+
+        type_ref
+    }
+
+    /// Attempts to instantiate a new [`Instance`] from an existing
+    /// type-reference and a set of generic arguments. This is shorthand for:
+    /// ```ignore (illustrative)
+    /// mcx.instance_of_type(mcx.instantiated_type(type_ref, generics))
+    /// ```
+    ///
+    /// **Arguments**:
+    /// - `type_ref`: type reference to instantiate.
+    /// - `generics`: any type arguments supplied for the type. Could be the
+    ///   generics from a call site or supplied by the user.
+    ///
+    /// # Example
+    ///
+    /// Let's say we want to instantiat the type of `value`:
+    /// ```lm (ignore,illustration)
+    /// fn foo() {
+    ///   let value = bar<T, UInt32>();
+    /// }
+    /// ```
+    /// would result in the arguments of:
+    /// - `type_ref = type_of(value)`
+    /// - `generics = [T, UInt32])`
+    pub fn instantiated_type_instance(&self, type_ref: TypeRef, generics: &Generics) -> Instance {
+        self.instance_of_type(self.instantiated_type(type_ref, generics))
     }
 }

--- a/compiler/lume_mir_queries/src/instance.rs
+++ b/compiler/lume_mir_queries/src/instance.rs
@@ -6,24 +6,26 @@ use crate::MirQueryCtx;
 
 impl MirQueryCtx<'_> {
     #[inline]
-    pub fn instance_of(&self, func: NodeId, type_arguments: Vec<TypeRef>) -> lume_mir::Instance {
-        let type_parameter_ids = self.tcx().available_type_params_at(func);
+    pub fn instance_of(&self, id: NodeId, type_arguments: Vec<TypeRef>) -> lume_mir::Instance {
+        let type_parameter_ids = self.tcx().all_type_parameters_of(id);
         // debug_assert_eq!(type_parameter_ids.len(), type_arguments.len());
 
         if type_arguments.is_empty() {
-            return lume_mir::Instance {
-                id: func,
-                generics: None,
-            };
+            return lume_mir::Instance { id, generics: None };
         }
 
         lume_mir::Instance {
-            id: func,
+            id,
             generics: Some(lume_mir::Generics {
                 ids: type_parameter_ids,
                 types: type_arguments,
             }),
         }
+    }
+
+    #[inline]
+    pub fn instance_of_type(&self, ty: TypeRef) -> lume_mir::Instance {
+        self.instance_of(ty.instance_of, ty.bound_types)
     }
 
     /// Attempts to instantiate a new [`Instance`] from an existing MIR call

--- a/compiler/lume_mir_queries/src/instance.rs
+++ b/compiler/lume_mir_queries/src/instance.rs
@@ -1,0 +1,67 @@
+use lume_mir::Instance;
+use lume_span::NodeId;
+use lume_types::TypeRef;
+
+use crate::MirQueryCtx;
+
+impl MirQueryCtx<'_> {
+    #[inline]
+    pub fn instance_of(&self, func: NodeId, type_arguments: Vec<TypeRef>) -> lume_mir::Instance {
+        let type_parameter_ids = self.tcx().available_type_params_at(func);
+        // debug_assert_eq!(type_parameter_ids.len(), type_arguments.len());
+
+        if type_arguments.is_empty() {
+            return lume_mir::Instance {
+                id: func,
+                generics: None,
+            };
+        }
+
+        lume_mir::Instance {
+            id: func,
+            generics: Some(lume_mir::Generics {
+                ids: type_parameter_ids,
+                types: type_arguments,
+            }),
+        }
+    }
+
+    /// Attempts to instantiate a new [`Instance`] from an existing MIR call
+    /// site.
+    ///
+    /// **Arguments**:
+    /// - `owner`: function instance in which the call expression is located.
+    /// - `func`: ID of the function which the call expression calls.
+    /// - `type_arguments`: any type arguments supplied at the call site.
+    ///
+    /// # Example
+    ///
+    /// ```lm (ignore,illustration)
+    /// fn foo<T>() {
+    ///   let _ = bar<T, UInt32>();
+    /// }
+    /// ```
+    /// would result in the arguments of:
+    /// - `owner = instance_of(foo<T>)`
+    /// - `func = node_id_of(bar<T>)`
+    /// - `type_arguments = [T, UInt32])`
+    pub fn instantiated_instance(&self, owner: &Instance, func: NodeId, type_arguments: Vec<TypeRef>) -> Instance {
+        let mut instance = self.instance_of(func, type_arguments);
+
+        let Some(instance_generics) = &mut instance.generics else {
+            return instance;
+        };
+
+        let Some(owner_generics) = &owner.generics else {
+            return instance;
+        };
+
+        for type_argument in &mut instance_generics.types {
+            for (type_parameter_id, replacement) in owner_generics.iter() {
+                type_argument.replace_contained(type_parameter_id, replacement);
+            }
+        }
+
+        instance
+    }
+}

--- a/compiler/lume_mir_queries/src/lib.rs
+++ b/compiler/lume_mir_queries/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod analysis;
+pub mod instance;
 pub mod lookup;
 pub mod opts;
 pub mod patch;

--- a/compiler/lume_mir_queries/src/opts.rs
+++ b/compiler/lume_mir_queries/src/opts.rs
@@ -12,14 +12,17 @@ impl MirQueryCtx<'_> {
     #[inline]
     pub fn should_dump_func(&self, func: &Function, pass: Option<&str>) -> bool {
         let opts = &self.gcx().session.options;
+        let func_name = func.name.clone_inner();
 
-        // Defines whether all functions should be dumped.
+        // Defines whether all functions should be dumped...
         let include_all_funcs = opts.dump_mir.is_some() && opts.dump_mir_func.is_empty();
+
+        // ...and whether this specific function should be dumped.
+        let include_this_func = opts.dump_mir_func.iter().any(|name| func_name.starts_with(name));
 
         // Determines whether the function should be dumped - but only if the
         // pass isn't rejected!
-        let func_name = func.name.clone_inner();
-        let should_dump_function = include_all_funcs || opts.dump_mir_func.contains(&func_name);
+        let should_dump_function = include_all_funcs || include_this_func;
 
         match (opts.dump_mir.as_ref(), pass) {
             // If `--dump-mir` was passed without any specific passes, return
@@ -47,7 +50,7 @@ impl MirQueryCtx<'_> {
 
             // If outside of any MIR pass when `--dump-mir-func` is passed,
             // only dump the requested functions.
-            (_, None) if !include_all_funcs => opts.dump_mir_func.contains(&func_name),
+            (_, None) if !include_all_funcs => include_this_func,
 
             // If neither `--dump-mir` nor `--dump-mir-func` was passed, dump nothing.
             (_, _) => false,

--- a/compiler/lume_mono/Cargo.toml
+++ b/compiler/lume_mono/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lume_mir_lower"
+name = "lume_mono"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -8,17 +8,15 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
+lume_errors = { path = "../../crates/lume_errors" }
 lume_hir = { path = "../lume_hir" }
-lume_mangle = { path = "../../crates/lume_mangle" }
+lume_infer = { path = "../lume_infer" }
 lume_mir = { path = "../lume_mir" }
 lume_mir_queries = { path = "../lume_mir_queries" }
-lume_mono = { path = "../lume_mono" }
 lume_session = { path = "../lume_session" }
 lume_span = { path = "../../crates/lume_span" }
-lume_tir = { path = "../lume_tir" }
 lume_typech = { path = "../lume_typech" }
 lume_types = { path = "../lume_types" }
-lume_type_metadata = { path = "../lume_type_metadata" }
 
 indexmap = { workspace = true }
 tracing = { workspace = true }

--- a/compiler/lume_mono/Cargo.toml
+++ b/compiler/lume_mono/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 lume_errors = { path = "../../crates/lume_errors" }
 lume_hir = { path = "../lume_hir" }
 lume_infer = { path = "../lume_infer" }
+lume_mangle = { path = "../../crates/lume_mangle" }
 lume_mir = { path = "../lume_mir" }
 lume_mir_queries = { path = "../lume_mir_queries" }
 lume_session = { path = "../lume_session" }

--- a/compiler/lume_mono/src/canonicalize.rs
+++ b/compiler/lume_mono/src/canonicalize.rs
@@ -2,11 +2,11 @@ use indexmap::IndexMap;
 use lume_mir_queries::MirQueryCtx;
 use lume_span::Internable;
 
-use crate::Instance;
+use crate::{Instance, MonoItems};
 
 #[tracing::instrument(level = "DEBUG", skip_all, fields(package = mcx.tcx().current_package().name))]
-pub fn canonicalize(mcx: &mut MirQueryCtx<'_>) {
-    let mono_items = crate::collect(mcx).unwrap();
+pub fn canonicalize(mcx: &mut MirQueryCtx<'_>) -> MonoItems {
+    let mono_items = crate::collect(mcx).expect("failed to collect mono items");
     let functions = mcx.mir().functions.values().map(|func| func.id).collect::<Vec<_>>();
 
     for func_id in functions {
@@ -28,6 +28,18 @@ pub fn canonicalize(mcx: &mut MirQueryCtx<'_>) {
         }
 
         if !mono_functions.is_empty() {
+            if tracing::enabled!(tracing::Level::DEBUG) {
+                tracing::debug!(
+                    base = %base_instance.display(mcx.tcx()),
+                    inst = %mono_functions
+                        .keys()
+                        .map(|inst| format!("{inst:?}").to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    "monomorphized_function",
+                );
+            }
+
             mcx.mir_mut().functions.shift_remove(&base_instance);
             mcx.mir_mut().functions.extend(mono_functions);
         }
@@ -39,12 +51,13 @@ pub fn canonicalize(mcx: &mut MirQueryCtx<'_>) {
     };
 
     let mut replacement_funcs = mcx.mir().functions.clone();
-
     for func in replacement_funcs.values_mut() {
         lume_mir::walk::walk_mut(func, &mut visitor);
     }
 
     mcx.mir_mut().functions.extend(replacement_funcs);
+
+    mono_items
 }
 
 fn canonicalize_body(
@@ -57,7 +70,7 @@ fn canonicalize_body(
     };
 
     let mut func = func.clone();
-    func.instance = Some(instance.to_owned());
+    func.instance = instance.clone();
 
     let mangle_version = lume_mangle::Version::default();
     let mangle_instance = lume_mangle::Instance {
@@ -79,7 +92,7 @@ struct UpdateCallInstance<'mcx, 'tcx> {
 
 impl lume_mir::walk::VisitorMut for UpdateCallInstance<'_, '_> {
     fn visit_function(&mut self, func: &mut lume_mir::Function) {
-        func.instance.clone_into(&mut self.function_instance);
+        self.function_instance = Some(func.instance.clone());
     }
 
     fn visit_declaration(&mut self, decl: &mut lume_mir::Declaration) {

--- a/compiler/lume_mono/src/canonicalize.rs
+++ b/compiler/lume_mono/src/canonicalize.rs
@@ -1,0 +1,22 @@
+use lume_mir_queries::MirQueryCtx;
+
+use crate::Instance;
+
+pub fn canonicalize(
+    mcx: &MirQueryCtx<'_>,
+    func: &lume_mir::Function,
+    instance: &Instance,
+) -> Option<lume_mir::Function> {
+    let Some(generics) = &instance.generics else {
+        return None;
+    };
+
+    if generics.is_empty() {
+        return None;
+    }
+
+    let mut func = func.clone();
+    func.instance = Some(instance.to_owned());
+
+    Some(func)
+}

--- a/compiler/lume_mono/src/canonicalize.rs
+++ b/compiler/lume_mono/src/canonicalize.rs
@@ -105,14 +105,10 @@ impl lume_mir::walk::VisitorMut for UpdateCallInstance<'_, '_> {
                 "update_call_site"
             );
 
-            let new_name = inst_instance
-                .display(self.mcx.tcx())
-                .to_string()
-                .trim_end_matches(['(', ')'])
-                .to_string();
+            let new_name = inst_instance.display(self.mcx.tcx()).to_string();
+            *name = new_name.intern();
 
             *instance = inst_instance;
-            *name = new_name.intern();
         }
     }
 }

--- a/compiler/lume_mono/src/canonicalize.rs
+++ b/compiler/lume_mono/src/canonicalize.rs
@@ -1,8 +1,53 @@
+use indexmap::IndexMap;
 use lume_mir_queries::MirQueryCtx;
+use lume_span::Internable;
 
 use crate::Instance;
 
-pub fn canonicalize(
+#[tracing::instrument(level = "DEBUG", skip_all, fields(package = mcx.tcx().current_package().name))]
+pub fn canonicalize(mcx: &mut MirQueryCtx<'_>) {
+    let mono_items = crate::collect(mcx).unwrap();
+    let functions = mcx.mir().functions.values().map(|func| func.id).collect::<Vec<_>>();
+
+    for func_id in functions {
+        if !mono_items.any_of(func_id) {
+            continue;
+        }
+
+        let base_instance = lume_mir::Instance::from(func_id);
+        let base_mir_func = mcx.mir().instance(&base_instance);
+        let mut mono_functions = IndexMap::new();
+
+        for instance in mono_items.all_of(func_id) {
+            let Some(canon_mir_func) = canonicalize_body(mcx, base_mir_func, instance) else {
+                tracing::debug!("skipping canonicalization for {}", instance.display(mcx.tcx()));
+                continue;
+            };
+
+            mono_functions.insert(instance.to_owned(), canon_mir_func);
+        }
+
+        if !mono_functions.is_empty() {
+            mcx.mir_mut().functions.shift_remove(&base_instance);
+            mcx.mir_mut().functions.extend(mono_functions);
+        }
+    }
+
+    let mut visitor = UpdateCallInstance {
+        mcx,
+        function_instance: None,
+    };
+
+    let mut replacement_funcs = mcx.mir().functions.clone();
+
+    for func in replacement_funcs.values_mut() {
+        lume_mir::walk::walk_mut(func, &mut visitor);
+    }
+
+    mcx.mir_mut().functions.extend(replacement_funcs);
+}
+
+fn canonicalize_body(
     mcx: &MirQueryCtx<'_>,
     func: &lume_mir::Function,
     instance: &Instance,
@@ -11,12 +56,63 @@ pub fn canonicalize(
         return None;
     };
 
-    if generics.is_empty() {
-        return None;
-    }
-
     let mut func = func.clone();
     func.instance = Some(instance.to_owned());
 
+    let mangle_version = lume_mangle::Version::default();
+    let mangle_instance = lume_mangle::Instance {
+        id: func.id,
+        generics: generics.iter().map(|(id, arg)| (id, arg.clone())).collect(),
+    };
+
+    func.name = instance.display(mcx.tcx()).to_string().intern();
+    func.mangled_name = lume_mangle::mangled(mcx.tcx(), &mangle_instance, mangle_version)
+        .unwrap_or_else(|_| panic!("bug!: could not mangle instance {}", instance.display(mcx.tcx())));
+
     Some(func)
+}
+
+struct UpdateCallInstance<'mcx, 'tcx> {
+    mcx: &'mcx MirQueryCtx<'tcx>,
+    function_instance: Option<Instance>,
+}
+
+impl lume_mir::walk::VisitorMut for UpdateCallInstance<'_, '_> {
+    fn visit_function(&mut self, func: &mut lume_mir::Function) {
+        func.instance.clone_into(&mut self.function_instance);
+    }
+
+    fn visit_declaration(&mut self, decl: &mut lume_mir::Declaration) {
+        let Some(func_instance) = self.function_instance.as_ref() else {
+            return;
+        };
+
+        if let lume_mir::DeclarationKind::Call {
+            instance,
+            name,
+            type_args,
+            ..
+        } = decl.kind.as_mut()
+        {
+            let inst_instance = self
+                .mcx
+                .instantiated_instance(func_instance, instance.id, std::mem::take(type_args));
+
+            tracing::trace!(
+                owner = &func_instance.display(self.mcx.tcx()).to_string(),
+                before = &instance.display(self.mcx.tcx()).to_string(),
+                after = &inst_instance.display(self.mcx.tcx()).to_string(),
+                "update_call_site"
+            );
+
+            let new_name = inst_instance
+                .display(self.mcx.tcx())
+                .to_string()
+                .trim_end_matches(['(', ')'])
+                .to_string();
+
+            *instance = inst_instance;
+            *name = new_name.intern();
+        }
+    }
 }

--- a/compiler/lume_mono/src/collector.rs
+++ b/compiler/lume_mono/src/collector.rs
@@ -4,18 +4,22 @@ use lume_hir::CallExpression;
 use lume_mir_queries::MirQueryCtx;
 use lume_span::NodeId;
 use lume_typech::TyCheckCtx;
+use lume_types::TypeRef;
 
 use crate::{Generics, Instance, MonoItems};
 
+#[tracing::instrument(level = "INFO", skip_all, fields(package = mcx.tcx().current_package().name), err)]
 pub fn collect(mcx: &MirQueryCtx<'_>) -> Result<MonoItems> {
     let mut items = MonoItems::default();
     items.extend(collect_roots(mcx)?);
 
+    collect_monotypes(mcx, &mut items)?;
+
     Ok(items)
 }
 
-#[tracing::instrument(level = "INFO", skip_all, fields(package = mcx.tcx().current_package().name), err)]
-pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>> {
+#[tracing::instrument(level = "DEBUG", skip_all, fields(package = mcx.tcx().current_package().name), err)]
+fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>> {
     let tcx = mcx.tcx();
     let mir = mcx.mir();
 
@@ -56,17 +60,17 @@ pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>>
         tracing::debug!(item = workitem.display(tcx).to_string(), "collected");
 
         let generics = workitem.generics.clone().unwrap_or_default();
-        let type_parameters = tcx.type_params_of(workitem.id)?;
+        let type_parameters = tcx.canonical_type_parameters_of(workitem.id)?;
         debug_assert_eq!(type_parameters.len(), generics.len());
 
         for CallLocation { call_expr, callable_id } in visitor.calls_in(tcx.hir(), workitem.id)? {
-            let generic_params = tcx.type_params_of(callable_id)?;
+            let generic_params = tcx.canonical_type_parameters_of(callable_id)?;
 
             let generic_args = tcx
                 .mk_type_refs_from(call_expr.type_arguments(), call_expr.id())?
                 .into_iter()
                 .map(|type_arg| {
-                    tcx.instantiate_flat_type_from(&type_arg, type_parameters, &generics.types)
+                    tcx.instantiate_flat_type_from(&type_arg, &type_parameters, &generics.types)
                         .to_owned()
                 })
                 .collect::<Vec<_>>();
@@ -74,7 +78,7 @@ pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>>
             let call_instance = Instance {
                 id: callable_id,
                 generics: Some(Generics {
-                    ids: generic_params.to_vec(),
+                    ids: generic_params,
                     types: generic_args,
                 }),
             };
@@ -136,4 +140,111 @@ impl<'hir> lume_hir::Visitor<'hir> for CallVisitor<'_, 'hir> {
 
         Ok(())
     }
+}
+
+#[tracing::instrument(level = "DEBUG", skip_all, fields(package = mcx.tcx().current_package().name), err)]
+fn collect_monotypes(mcx: &MirQueryCtx<'_>, items: &mut MonoItems) -> Result<()> {
+    // TODO:
+    // I'd like to believe there's a better (ie. less-allocating)
+    // way of doing this.
+
+    let mut visited = IndexSet::new();
+    let mut worklist = IndexSet::new();
+
+    // NOTE:
+    // This first "seeding" of the worklist contains instances which refer to
+    // *callables*, where-as all later entries will refer to *types*.
+    for instance in items.instances.values().flatten() {
+        worklist.insert(instance.clone());
+    }
+
+    while let Some(instance) = worklist.pop() {
+        if visited.contains(&instance) {
+            continue;
+        }
+
+        let instance_generics = instance.generics.clone().unwrap_or_default();
+
+        if mcx.tcx().tdb().expect_type(instance.id).is_ok() {
+            let instance_type = TypeRef {
+                instance_of: instance.id,
+                bound_types: instance_generics.types.clone(),
+                ..Default::default()
+            };
+
+            for field in mcx.tcx().hir_fields_on(instance.id)? {
+                let field_type = mcx.tcx().mk_type_ref_from(&field.field_type, instance.id)?;
+                let field_instance = monotype_of(mcx, field_type, &instance_generics);
+
+                worklist.insert(field_instance);
+            }
+
+            for method in mcx.tcx().methods_defined_on(&instance_type) {
+                for parameter in mcx.tcx().parameters_of(method.id) {
+                    let parameter_type = mcx.tcx().mk_type_ref_from(&parameter.param_type, method.id)?;
+                    let parameter_instance = monotype_of(mcx, parameter_type, &instance_generics);
+
+                    worklist.insert(parameter_instance);
+                }
+
+                let return_type = mcx
+                    .tcx()
+                    .mk_type_ref_from(mcx.tcx().return_type_of(method.id).unwrap(), method.id)?;
+
+                let return_instance = monotype_of(mcx, return_type, &instance_generics);
+                worklist.insert(return_instance);
+            }
+
+            items.types.insert(instance_type);
+        }
+
+        for bound_type in &instance_generics.types {
+            worklist.insert(mcx.instance_of_type(bound_type.clone()));
+        }
+
+        visited.insert(instance);
+    }
+
+    for generic_type in &items.types {
+        tracing::trace!(
+            name = mcx
+                .tcx()
+                .ty_stringifier(generic_type)
+                .include_namespace(true)
+                .stringify()?,
+            "monotype"
+        );
+    }
+
+    Ok(())
+}
+
+/// Create an instantiated [`Instance`] from the given [`TypeRef`], using the
+/// generics from the surrounding context.
+fn monotype_of(mcx: &MirQueryCtx, mut type_: TypeRef, generics: &Generics) -> Instance {
+    // Replace all contained type parameters with their respective canonical type
+    // parameter. This helps with mapping the correct type arguments into the
+    // type-ref, as they might not use the same type parameter IDs.
+    for bound_type in type_.walk_mut() {
+        if !bound_type.bound_types.is_empty() || !mcx.tcx().is_type_parameter(bound_type) {
+            continue;
+        }
+
+        let Some(owner) = mcx.tcx().hir_parent_node_of(bound_type.instance_of) else {
+            continue;
+        };
+
+        if let Ok(Some(canonical)) = mcx
+            .tcx()
+            .hir_canonical_type_of(lume_hir::TypeId::from(bound_type.instance_of), owner.id())
+        {
+            bound_type.instance_of = canonical.as_node_id();
+        }
+    }
+
+    for (type_parameter_id, replacement) in generics.iter() {
+        type_.replace_contained(type_parameter_id, replacement);
+    }
+
+    mcx.instance_of_type(type_)
 }

--- a/compiler/lume_mono/src/collector.rs
+++ b/compiler/lume_mono/src/collector.rs
@@ -174,7 +174,7 @@ fn collect_monotypes(mcx: &MirQueryCtx<'_>, items: &mut MonoItems) -> Result<()>
 
             for field in mcx.tcx().hir_fields_on(instance.id)? {
                 let field_type = mcx.tcx().mk_type_ref_from(&field.field_type, instance.id)?;
-                let field_instance = monotype_of(mcx, field_type, &instance_generics);
+                let field_instance = mcx.instantiated_type_instance(field_type, &instance_generics);
 
                 worklist.insert(field_instance);
             }
@@ -182,7 +182,7 @@ fn collect_monotypes(mcx: &MirQueryCtx<'_>, items: &mut MonoItems) -> Result<()>
             for method in mcx.tcx().methods_defined_on(&instance_type) {
                 for parameter in mcx.tcx().parameters_of(method.id) {
                     let parameter_type = mcx.tcx().mk_type_ref_from(&parameter.param_type, method.id)?;
-                    let parameter_instance = monotype_of(mcx, parameter_type, &instance_generics);
+                    let parameter_instance = mcx.instantiated_type_instance(parameter_type, &instance_generics);
 
                     worklist.insert(parameter_instance);
                 }
@@ -191,7 +191,7 @@ fn collect_monotypes(mcx: &MirQueryCtx<'_>, items: &mut MonoItems) -> Result<()>
                     .tcx()
                     .mk_type_ref_from(mcx.tcx().return_type_of(method.id).unwrap(), method.id)?;
 
-                let return_instance = monotype_of(mcx, return_type, &instance_generics);
+                let return_instance = mcx.instantiated_type_instance(return_type, &instance_generics);
                 worklist.insert(return_instance);
             }
 
@@ -217,34 +217,4 @@ fn collect_monotypes(mcx: &MirQueryCtx<'_>, items: &mut MonoItems) -> Result<()>
     }
 
     Ok(())
-}
-
-/// Create an instantiated [`Instance`] from the given [`TypeRef`], using the
-/// generics from the surrounding context.
-fn monotype_of(mcx: &MirQueryCtx, mut type_: TypeRef, generics: &Generics) -> Instance {
-    // Replace all contained type parameters with their respective canonical type
-    // parameter. This helps with mapping the correct type arguments into the
-    // type-ref, as they might not use the same type parameter IDs.
-    for bound_type in type_.walk_mut() {
-        if !bound_type.bound_types.is_empty() || !mcx.tcx().is_type_parameter(bound_type) {
-            continue;
-        }
-
-        let Some(owner) = mcx.tcx().hir_parent_node_of(bound_type.instance_of) else {
-            continue;
-        };
-
-        if let Ok(Some(canonical)) = mcx
-            .tcx()
-            .hir_canonical_type_of(lume_hir::TypeId::from(bound_type.instance_of), owner.id())
-        {
-            bound_type.instance_of = canonical.as_node_id();
-        }
-    }
-
-    for (type_parameter_id, replacement) in generics.iter() {
-        type_.replace_contained(type_parameter_id, replacement);
-    }
-
-    mcx.instance_of_type(type_)
 }

--- a/compiler/lume_mono/src/collector.rs
+++ b/compiler/lume_mono/src/collector.rs
@@ -1,0 +1,133 @@
+use indexmap::IndexSet;
+use lume_errors::Result;
+use lume_hir::CallExpression;
+use lume_mir_queries::MirQueryCtx;
+use lume_span::NodeId;
+use lume_typech::TyCheckCtx;
+
+use crate::{Instance, MonoItems};
+
+pub fn collect(mcx: &MirQueryCtx<'_>) -> Result<MonoItems> {
+    let mut items = MonoItems::default();
+    items.extend(collect_roots(mcx)?);
+
+    Ok(items)
+}
+
+#[tracing::instrument(level = "INFO", skip_all, fields(package = mcx.tcx().current_package().name), err)]
+pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>> {
+    let tcx = mcx.tcx();
+    let mir = mcx.mir();
+
+    let mut instances = IndexSet::new();
+    let mut worklist = IndexSet::new();
+
+    // Ensure the main entrypoint is inserted as a root, if one is available, since
+    // it cannot be generic.
+    //
+    // TODO: ensure the signature of the entrypoint is as expected.
+    if let Some(main_fn) = tcx.entrypoint() {
+        worklist.insert(Instance {
+            id: main_fn.id,
+            generics: Vec::new(),
+        });
+    }
+
+    // Add all public, concrete (non-generic) functions and methods into the root
+    // set, since we can be sure they are already monomorphic.
+    for mir_func in mir
+        .functions
+        .values()
+        .filter(|func| !func.signature.internal && !func.signature.external && !tcx.is_node_generic(func.id))
+    {
+        worklist.insert(Instance {
+            id: mir_func.id,
+            generics: Vec::new(),
+        });
+    }
+
+    let mut visitor = CallVisitor::new(tcx);
+
+    while let Some(workitem) = worklist.pop() {
+        if instances.contains(&workitem) {
+            continue;
+        }
+
+        tracing::debug!(item = workitem.display(tcx).to_string(), "collected");
+
+        let type_parameters = tcx.type_params_of(workitem.id)?;
+        debug_assert_eq!(type_parameters.len(), workitem.generics.len());
+
+        for CallLocation { call_expr, callable_id } in visitor.calls_in(tcx.hir(), workitem.id)? {
+            let generic_args = tcx
+                .mk_type_refs_from(call_expr.type_arguments(), call_expr.id())?
+                .into_iter()
+                .map(|type_arg| {
+                    tcx.instantiate_flat_type_from(&type_arg, type_parameters, &workitem.generics)
+                        .to_owned()
+                })
+                .collect::<Vec<_>>();
+
+            let call_instance = Instance {
+                id: callable_id,
+                generics: generic_args,
+            };
+
+            tracing::trace!(
+                from = tcx.hir_path_of_node(workitem.id).to_wide_string(),
+                to = call_instance.display(tcx).to_string(),
+                "call_edge",
+            );
+
+            worklist.insert(call_instance);
+        }
+
+        instances.insert(workitem);
+    }
+
+    Ok(instances)
+}
+
+struct CallVisitor<'tcx, 'hir> {
+    tcx: &'tcx TyCheckCtx,
+    call_graph: IndexSet<CallLocation<'hir>>,
+}
+
+impl<'tcx, 'hir> CallVisitor<'tcx, 'hir> {
+    pub fn new(tcx: &'tcx TyCheckCtx) -> Self {
+        Self {
+            tcx,
+            call_graph: IndexSet::new(),
+        }
+    }
+
+    pub fn calls_in(&mut self, hir: &'hir lume_hir::Map, id: NodeId) -> Result<IndexSet<CallLocation<'hir>>> {
+        lume_hir::traverse_node(hir, self, hir.expect_node(id).unwrap())?;
+
+        Ok(std::mem::take(&mut self.call_graph))
+    }
+}
+
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
+struct CallLocation<'tcx> {
+    pub call_expr: CallExpression<'tcx>,
+    pub callable_id: NodeId,
+}
+
+impl<'hir> lume_hir::Visitor<'hir> for CallVisitor<'_, 'hir> {
+    fn visit_expr(&mut self, expr: &'hir lume_hir::Expression) -> Result<()> {
+        let call_expr = match &expr.kind {
+            lume_hir::ExpressionKind::InstanceCall(call) => CallExpression::Instanced(call),
+            lume_hir::ExpressionKind::StaticCall(call) => CallExpression::Static(call),
+            lume_hir::ExpressionKind::IntrinsicCall(call) => CallExpression::Intrinsic(call),
+            _ => return Ok(()),
+        };
+
+        self.call_graph.insert(CallLocation {
+            call_expr,
+            callable_id: self.tcx.probe_callable(call_expr)?.id(),
+        });
+
+        Ok(())
+    }
+}

--- a/compiler/lume_mono/src/collector.rs
+++ b/compiler/lume_mono/src/collector.rs
@@ -31,10 +31,7 @@ fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>> {
     //
     // TODO: ensure the signature of the entrypoint is as expected.
     if let Some(main_fn) = tcx.entrypoint() {
-        worklist.insert(Instance {
-            id: main_fn.id,
-            generics: Some(Generics::default()),
-        });
+        worklist.insert(Instance::from(main_fn.id));
     }
 
     // Add all public, concrete (non-generic) functions and methods into the root
@@ -44,10 +41,7 @@ fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>> {
         .values()
         .filter(|func| !func.signature.internal && !func.signature.external && !tcx.is_node_generic(func.id))
     {
-        worklist.insert(Instance {
-            id: mir_func.id,
-            generics: Some(Generics::default()),
-        });
+        worklist.insert(Instance::from(mir_func.id));
     }
 
     let mut visitor = CallVisitor::new(tcx);
@@ -75,13 +69,10 @@ fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>> {
                 })
                 .collect::<Vec<_>>();
 
-            let call_instance = Instance {
-                id: callable_id,
-                generics: Some(Generics {
-                    ids: generic_params,
-                    types: generic_args,
-                }),
-            };
+            let call_instance = Instance::new(callable_id, Generics {
+                ids: generic_params,
+                types: generic_args,
+            });
 
             tracing::trace!(
                 from = tcx.hir_path_of_node(workitem.id).to_wide_string(),

--- a/compiler/lume_mono/src/collector.rs
+++ b/compiler/lume_mono/src/collector.rs
@@ -5,7 +5,7 @@ use lume_mir_queries::MirQueryCtx;
 use lume_span::NodeId;
 use lume_typech::TyCheckCtx;
 
-use crate::{Instance, MonoItems};
+use crate::{Generics, Instance, MonoItems};
 
 pub fn collect(mcx: &MirQueryCtx<'_>) -> Result<MonoItems> {
     let mut items = MonoItems::default();
@@ -29,7 +29,7 @@ pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>>
     if let Some(main_fn) = tcx.entrypoint() {
         worklist.insert(Instance {
             id: main_fn.id,
-            generics: Vec::new(),
+            generics: Some(Generics::default()),
         });
     }
 
@@ -42,7 +42,7 @@ pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>>
     {
         worklist.insert(Instance {
             id: mir_func.id,
-            generics: Vec::new(),
+            generics: Some(Generics::default()),
         });
     }
 
@@ -55,22 +55,28 @@ pub(crate) fn collect_roots(mcx: &MirQueryCtx<'_>) -> Result<IndexSet<Instance>>
 
         tracing::debug!(item = workitem.display(tcx).to_string(), "collected");
 
+        let generics = workitem.generics.clone().unwrap_or_default();
         let type_parameters = tcx.type_params_of(workitem.id)?;
-        debug_assert_eq!(type_parameters.len(), workitem.generics.len());
+        debug_assert_eq!(type_parameters.len(), generics.len());
 
         for CallLocation { call_expr, callable_id } in visitor.calls_in(tcx.hir(), workitem.id)? {
+            let generic_params = tcx.type_params_of(callable_id)?;
+
             let generic_args = tcx
                 .mk_type_refs_from(call_expr.type_arguments(), call_expr.id())?
                 .into_iter()
                 .map(|type_arg| {
-                    tcx.instantiate_flat_type_from(&type_arg, type_parameters, &workitem.generics)
+                    tcx.instantiate_flat_type_from(&type_arg, type_parameters, &generics.types)
                         .to_owned()
                 })
                 .collect::<Vec<_>>();
 
             let call_instance = Instance {
                 id: callable_id,
-                generics: generic_args,
+                generics: Some(Generics {
+                    ids: generic_params.to_vec(),
+                    types: generic_args,
+                }),
             };
 
             tracing::trace!(

--- a/compiler/lume_mono/src/lib.rs
+++ b/compiler/lume_mono/src/lib.rs
@@ -1,52 +1,12 @@
 use indexmap::{IndexMap, IndexSet};
+use lume_mir::{Generics, Instance};
 use lume_span::NodeId;
-use lume_typech::TyCheckCtx;
-use lume_types::TypeRef;
 
 pub(crate) mod collector;
 pub use collector::collect;
 
-#[derive(Hash, Debug, Clone, PartialEq, Eq)]
-pub struct Instance {
-    /// ID of the method or function which this instance represents.
-    pub id: NodeId,
-
-    /// Generic arguments for the callable instance
-    pub generics: Vec<TypeRef>,
-}
-
-impl Instance {
-    pub fn display<'tcx>(&'tcx self, tcx: &'tcx TyCheckCtx) -> InstanceDisplay<'tcx> {
-        InstanceDisplay(self, tcx)
-    }
-}
-
-pub struct InstanceDisplay<'tcx>(&'tcx Instance, &'tcx TyCheckCtx);
-
-impl std::fmt::Display for InstanceDisplay<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let InstanceDisplay(instance, tcx) = self;
-
-        write!(f, "{:+}", tcx.hir_path_of_node(instance.id))?;
-
-        if !instance.generics.is_empty() {
-            write!(
-                f,
-                "<{}>",
-                instance
-                    .generics
-                    .iter()
-                    .filter_map(|generic| tcx.ty_stringifier(generic).stringify().ok())
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            )?;
-        }
-
-        write!(f, "()")?;
-
-        Ok(())
-    }
-}
+pub(crate) mod canonicalize;
+pub use canonicalize::canonicalize;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct MonoItems {
@@ -60,6 +20,10 @@ impl MonoItems {
 
     pub fn iter(&self) -> impl Iterator<Item = &Instance> {
         self.items.values().flatten()
+    }
+
+    pub fn any_of(&self, id: NodeId) -> bool {
+        self.items.get(&id).is_some_and(|set| !set.is_empty())
     }
 
     pub fn all_of(&self, id: NodeId) -> impl Iterator<Item = &Instance> {

--- a/compiler/lume_mono/src/lib.rs
+++ b/compiler/lume_mono/src/lib.rs
@@ -7,29 +7,31 @@ pub use collector::collect;
 
 pub(crate) mod canonicalize;
 pub use canonicalize::canonicalize;
+use lume_types::TypeRef;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct MonoItems {
-    items: IndexMap<NodeId, IndexSet<Instance>>,
+    instances: IndexMap<NodeId, IndexSet<Instance>>,
+    types: IndexSet<TypeRef>,
 }
 
 impl MonoItems {
-    pub fn push(&mut self, item: Instance) {
-        self.items.entry(item.id).or_default().insert(item);
+    pub fn push_instance(&mut self, item: Instance) {
+        self.instances.entry(item.id).or_default().insert(item);
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Instance> {
-        self.items.values().flatten()
+        self.instances.values().flatten()
     }
 
     pub fn any_of(&self, id: NodeId) -> bool {
-        self.items.get(&id).is_some_and(|set| !set.is_empty())
+        self.instances.get(&id).is_some_and(|set| !set.is_empty())
     }
 
     pub fn all_of(&self, id: NodeId) -> impl Iterator<Item = &Instance> {
         static EMPTY: &indexmap::set::Slice<Instance> = indexmap::set::Slice::<Instance>::new();
 
-        self.items.get(&id).map_or(EMPTY.iter(), |set| set.iter())
+        self.instances.get(&id).map_or(EMPTY.iter(), |set| set.iter())
     }
 }
 
@@ -38,7 +40,7 @@ impl IntoIterator for MonoItems {
     type Item = Instance;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.items.into_values().flatten()
+        self.instances.into_values().flatten()
     }
 }
 
@@ -48,7 +50,7 @@ impl Extend<Instance> for MonoItems {
         I: IntoIterator<Item = Instance>,
     {
         for item in iter {
-            self.push(item);
+            self.push_instance(item);
         }
     }
 }

--- a/compiler/lume_mono/src/lib.rs
+++ b/compiler/lume_mono/src/lib.rs
@@ -1,0 +1,90 @@
+use indexmap::{IndexMap, IndexSet};
+use lume_span::NodeId;
+use lume_typech::TyCheckCtx;
+use lume_types::TypeRef;
+
+pub(crate) mod collector;
+pub use collector::collect;
+
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
+pub struct Instance {
+    /// ID of the method or function which this instance represents.
+    pub id: NodeId,
+
+    /// Generic arguments for the callable instance
+    pub generics: Vec<TypeRef>,
+}
+
+impl Instance {
+    pub fn display<'tcx>(&'tcx self, tcx: &'tcx TyCheckCtx) -> InstanceDisplay<'tcx> {
+        InstanceDisplay(self, tcx)
+    }
+}
+
+pub struct InstanceDisplay<'tcx>(&'tcx Instance, &'tcx TyCheckCtx);
+
+impl std::fmt::Display for InstanceDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let InstanceDisplay(instance, tcx) = self;
+
+        write!(f, "{:+}", tcx.hir_path_of_node(instance.id))?;
+
+        if !instance.generics.is_empty() {
+            write!(
+                f,
+                "<{}>",
+                instance
+                    .generics
+                    .iter()
+                    .filter_map(|generic| tcx.ty_stringifier(generic).stringify().ok())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )?;
+        }
+
+        write!(f, "()")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct MonoItems {
+    items: IndexMap<NodeId, IndexSet<Instance>>,
+}
+
+impl MonoItems {
+    pub fn push(&mut self, item: Instance) {
+        self.items.entry(item.id).or_default().insert(item);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Instance> {
+        self.items.values().flatten()
+    }
+
+    pub fn all_of(&self, id: NodeId) -> impl Iterator<Item = &Instance> {
+        static EMPTY: &indexmap::set::Slice<Instance> = indexmap::set::Slice::<Instance>::new();
+
+        self.items.get(&id).map_or(EMPTY.iter(), |set| set.iter())
+    }
+}
+
+impl IntoIterator for MonoItems {
+    type IntoIter = std::iter::Flatten<indexmap::map::IntoValues<NodeId, IndexSet<Instance>>>;
+    type Item = Instance;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_values().flatten()
+    }
+}
+
+impl Extend<Instance> for MonoItems {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Instance>,
+    {
+        for item in iter {
+            self.push(item);
+        }
+    }
+}

--- a/compiler/lume_tir_lower/src/expr.rs
+++ b/compiler/lume_tir_lower/src/expr.rs
@@ -112,7 +112,7 @@ impl LowerFunction<'_> {
             .map(|field| (field.name.name.clone(), field.clone()))
             .collect::<IndexMap<_, _>>();
 
-        let fields = self.lower.tcx.fields_on(constructed_type.instance_of)?;
+        let fields = self.lower.tcx.hir_fields_on(constructed_type.instance_of)?;
 
         for field in fields {
             if constructed.contains_key(&field.name.name) {
@@ -434,7 +434,7 @@ impl LowerFunction<'_> {
         let field = self
             .lower
             .tcx
-            .field_on(callee_ty.instance_of, expr.name.as_str())?
+            .hir_field_on(callee_ty.instance_of, expr.name.as_str())?
             .unwrap()
             .clone();
 

--- a/compiler/lume_tir_lower/src/lib.rs
+++ b/compiler/lume_tir_lower/src/lib.rs
@@ -262,7 +262,7 @@ impl<'tcx> LowerFunction<'tcx> {
         location: Location,
     ) -> Result<lume_tir::Function> {
         let name = self.path_hir(name, id)?;
-        let hir_type_params = self.lower.tcx.available_type_params_at(id);
+        let hir_type_params = self.lower.tcx.all_type_parameters_of(id);
 
         let parameters = self.parameters(signature.params);
         let type_params = self.type_parameters(&hir_type_params);

--- a/compiler/lume_tir_lower/src/metadata.rs
+++ b/compiler/lume_tir_lower/src/metadata.rs
@@ -67,7 +67,7 @@ impl<'tcx> MetadataBuilder<'tcx> {
                     // Take metadata pointer into account when calculating the size.
                     let mut size = PTR_SIZE;
 
-                    for prop in self.tcx.fields_on(struct_def.id)? {
+                    for prop in self.tcx.hir_fields_on(struct_def.id)? {
                         let prop_ty = self.tcx.mk_type_ref_from(&prop.field_type, struct_def.id)?;
 
                         size += if prop_ty.is_scalar_type() {
@@ -125,7 +125,7 @@ impl<'tcx> MetadataBuilder<'tcx> {
                     // We start at alignment 1, since an alignment of 0 is invalid.
                     let mut max_alignment = 1;
 
-                    for prop in self.tcx.fields_on(ty.instance_of)? {
+                    for prop in self.tcx.hir_fields_on(ty.instance_of)? {
                         let prop_ty = self.tcx.mk_type_ref_from(&prop.field_type, struct_def.id)?;
 
                         max_alignment = if self.tcx.tdb().is_reference_type(prop_ty.instance_of).unwrap() {
@@ -164,7 +164,7 @@ impl lume_type_metadata::visitor::Visitor for MetadataBuilder<'_> {
 
         let fields = self
             .tcx
-            .fields_on(type_ref.instance_of)?
+            .hir_fields_on(type_ref.instance_of)?
             .iter()
             .map(|field| field.id)
             .collect();
@@ -178,7 +178,7 @@ impl lume_type_metadata::visitor::Visitor for MetadataBuilder<'_> {
             .collect();
 
         let drop_method = self.find_drop_method(type_ref);
-        let type_parameters = self.tcx.available_type_params_at(type_id);
+        let type_parameters = self.tcx.all_type_parameters_of(type_id);
 
         let is_local = self.tcx.hir_is_local_node(type_id);
 

--- a/compiler/lume_tir_lower/src/path.rs
+++ b/compiler/lume_tir_lower/src/path.rs
@@ -20,7 +20,7 @@ impl LowerFunction<'_> {
     }
 
     pub(crate) fn path_hir(&self, path: &lume_hir::Path, hir_id: lume_span::NodeId) -> Result<lume_tir::Path> {
-        let type_params = self.lower.tcx.available_type_params_at(hir_id);
+        let type_params = self.lower.tcx.all_type_parameters_of(hir_id);
         let type_params = self.lower.tcx.as_type_params(&type_params)?;
 
         self.path(path, &type_params)

--- a/compiler/lume_tir_lower/src/reification.rs
+++ b/compiler/lume_tir_lower/src/reification.rs
@@ -151,7 +151,7 @@ impl ReificationPass<'_> {
     }
 
     fn add_metadata_arguments_on_call(&self, call: &mut Call) {
-        let type_param_len = self.tcx.available_type_params_at(call.function).len();
+        let type_param_len = self.tcx.all_type_parameters_of(call.function).len();
         let type_arg_len = call.type_arguments.len();
         let remaining_type_args = type_param_len.saturating_sub(type_arg_len);
 

--- a/compiler/lume_type_metadata/src/visitor.rs
+++ b/compiler/lume_type_metadata/src/visitor.rs
@@ -47,7 +47,7 @@ fn visit_type<V: Visitor>(state: &mut State<'_>, visitor: &mut V, ty: &lume_type
 
     visitor.visit_type(ty)?;
 
-    if let Some(type_param) = state.tcx.as_type_param(ty.instance_of) {
+    if let Some(type_param) = state.tcx.as_type_parameter(ty.instance_of) {
         visitor.visit_type_parameter(type_param)?;
     }
 
@@ -55,7 +55,7 @@ fn visit_type<V: Visitor>(state: &mut State<'_>, visitor: &mut V, ty: &lume_type
         visit_type(state, visitor, bound_type)?;
     }
 
-    for field in state.tcx.fields_on(ty.instance_of)? {
+    for field in state.tcx.hir_fields_on(ty.instance_of)? {
         visit_field(state, visitor, field)?;
     }
 
@@ -63,7 +63,7 @@ fn visit_type<V: Visitor>(state: &mut State<'_>, visitor: &mut V, ty: &lume_type
         visit_method(state, visitor, method)?;
     }
 
-    for type_param_id in state.tcx.available_type_params_at(ty.instance_of) {
+    for type_param_id in state.tcx.all_type_parameters_of(ty.instance_of) {
         let type_param = state.tcx.hir_expect_type_parameter(type_param_id);
 
         visit_type_parameter(state, visitor, type_param)?;
@@ -82,7 +82,7 @@ fn visit_field<V: Visitor>(state: &mut State<'_>, visitor: &mut V, field: &lume_
     let field_type = state.tcx.mk_type_ref_from(&field.field_type, field.id)?;
     visit_type(state, visitor, &field_type)?;
 
-    for type_param_id in state.tcx.available_type_params_at(field.id) {
+    for type_param_id in state.tcx.all_type_parameters_of(field.id) {
         let type_param = state.tcx.hir_expect_type_parameter(type_param_id);
 
         visit_type_parameter(state, visitor, type_param)?;
@@ -104,7 +104,7 @@ fn visit_method<V: Visitor>(state: &mut State<'_>, visitor: &mut V, method: &lum
         visit_parameter(state, visitor, parameter)?;
     }
 
-    for type_param_id in state.tcx.available_type_params_at(method.id) {
+    for type_param_id in state.tcx.all_type_parameters_of(method.id) {
         let type_param = state.tcx.hir_expect_type_parameter(type_param_id);
 
         visit_type_parameter(state, visitor, type_param)?;

--- a/compiler/lume_typech/src/check/expressions.rs
+++ b/compiler/lume_typech/src/check/expressions.rs
@@ -59,7 +59,7 @@ impl TyCheckCtx {
             if let Some(block) = &method.block {
                 self.define_block_scope(block)?;
 
-                let type_parameters_id = self.available_type_params_at(method.id);
+                let type_parameters_id = self.all_type_parameters_of(method.id);
                 let type_parameters = self.as_type_params(&type_parameters_id)?;
 
                 let return_type = self.mk_type_ref_generic(&method.signature.return_type, &type_parameters)?;
@@ -77,7 +77,7 @@ impl TyCheckCtx {
             if let Some(block) = &method.block {
                 self.define_block_scope(block)?;
 
-                let type_parameters_id = self.available_type_params_at(method.id);
+                let type_parameters_id = self.all_type_parameters_of(method.id);
                 let type_parameters = self.as_type_params(&type_parameters_id)?;
 
                 let return_type = self.mk_type_ref_generic(&method.signature.return_type, &type_parameters)?;
@@ -95,7 +95,7 @@ impl TyCheckCtx {
             if let Some(block) = &method.block {
                 self.define_block_scope(block)?;
 
-                let type_parameters_id = self.available_type_params_at(method.id);
+                let type_parameters_id = self.all_type_parameters_of(method.id);
                 let type_parameters = self.as_type_params(&type_parameters_id)?;
 
                 let return_type = self.mk_type_ref_generic(&method.signature.return_type, &type_parameters)?;
@@ -544,7 +544,7 @@ impl TyCheckCtx {
 
         let mut fields_left = expr.fields.iter().map(|field| &field.name).collect::<IndexSet<_>>();
 
-        for field in self.fields_on(constructed_type.instance_of)? {
+        for field in self.hir_fields_on(constructed_type.instance_of)? {
             let Some(constructor_field) = self.constructer_field_of(expr, field.name.as_str()) else {
                 self.dcx().emit(
                     MissingField {

--- a/compiler/lume_unification/src/constraints.rs
+++ b/compiler/lume_unification/src/constraints.rs
@@ -136,7 +136,7 @@ impl Engine<'_, TyInferCtx> {
         let callable = self.ctx.probe_callable(call)?;
         let signature = self.ctx.signature_of(callable)?;
 
-        let type_parameters = self.ctx.available_type_params_at(callable.id());
+        let type_parameters = self.ctx.all_type_parameters_of(callable.id());
         let type_arguments = call.all_type_arguments();
 
         let mut arguments = call.arguments();

--- a/compiler/lume_unification/src/introduce.rs
+++ b/compiler/lume_unification/src/introduce.rs
@@ -227,7 +227,7 @@ impl Engine<'_, TyInferCtx> {
 
         let type_def_id = type_def.id;
         let declared_type_args = path.bound_types().len();
-        let type_params = self.ctx.type_params_of(type_def.id)?.to_vec();
+        let type_params = self.ctx.type_parameters_of(type_def.id)?.to_vec();
 
         for type_param_id in type_params.into_iter().skip(declared_type_args) {
             let type_variable = self.fresh_var(type_def_id, type_param_id, location);
@@ -270,7 +270,7 @@ impl Engine<'_, TyInferCtx> {
 
         tracing::trace!(callable = %callable.name().to_wide_string());
 
-        let type_params = self.ctx.available_type_params_at(callable.id());
+        let type_params = self.ctx.all_type_parameters_of(callable.id());
         let type_args = call.all_type_arguments();
 
         // All all the type arguments have already been declared, theres

--- a/compiler/lume_unification/src/lib.rs
+++ b/compiler/lume_unification/src/lib.rs
@@ -122,7 +122,7 @@ impl Context for TyInferCtx {
     fn fresh_var(&mut self, owner: Self::ID, binding: Self::ID, location: Location) -> TypeVar<Self> {
         let id = NodeId::from_usize(self.hir().package, self.hir().nodes.len() + (usize::MAX / 2));
         let canonical = self
-            .hir_canonical_type_of(binding.into(), owner)
+            .hir_canonical_type_of(binding, owner)
             .map(|type_id| type_id.map_or(binding, |id| id.as_node_id()))
             .unwrap();
 

--- a/compiler/lume_unification/src/verify.rs
+++ b/compiler/lume_unification/src/verify.rs
@@ -122,7 +122,7 @@ pub(crate) fn verify_type_name(tcx: &TyInferCtx, path: &lume_hir::Path, location
         return;
     };
 
-    let expected_arg_count = tcx.type_params_of(matching_type.id).unwrap_or(&[]).len();
+    let expected_arg_count = tcx.type_parameters_of(matching_type.id).unwrap_or(&[]).len();
     let declared_arg_count = type_path.bound_types().len();
 
     if expected_arg_count != declared_arg_count {


### PR DESCRIPTION
Adds a new `lume_mono` crate for monomorphizing MIR functions:
- `collect()` function which collects all instantiated function signatures and used type references, collecting them into a single `MonoItems` structure
-  Adds `Instance` which denotes an instantiated version of a function/method signature. For example, instead of a single function such as `foo<T>()`, each instantiation of `foo` will have it's own `Instance`, such as `foo<Int32>()`, `foo<Bar>()`, etc.