### PR TITLE
perf(mlib): deduplicate source content when serialization `Location`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,7 @@ dependencies = [
  "lume_hir",
  "lume_infer",
  "lume_session",
+ "lume_span",
  "serde",
 ]
 

--- a/compiler/lume_driver/src/lib.rs
+++ b/compiler/lume_driver/src/lib.rs
@@ -6,7 +6,7 @@ use arc::locate_package;
 use indexmap::IndexMap;
 use lume_errors::{DiagCtxHandle, Result};
 use lume_session::{DependencyMap, FileLoader, Options, Package, Session};
-use lume_span::{FileName, PackageId, SourceFile};
+use lume_span::{FileName, PackageId, SourceFile, SourceMap};
 use lume_typech::TyCheckCtx;
 
 #[cfg(feature = "codegen")]
@@ -62,6 +62,7 @@ pub struct Driver<IO> {
 
     config: Config<IO>,
     dependencies: DependencyMap,
+    source_map: SourceMap,
 
     /// Defines the diagnostics context for reporting errors during compilation.
     dcx: DiagCtxHandle,
@@ -87,6 +88,11 @@ where
         Ok(Driver {
             package: dependencies.root_package().clone(),
             config,
+            source_map: dependencies
+                .packages
+                .values()
+                .flat_map(|package| package.files.values().cloned())
+                .collect(),
             dependencies,
             dcx,
         })

--- a/compiler/lume_driver/src/pipeline.rs
+++ b/compiler/lume_driver/src/pipeline.rs
@@ -44,6 +44,7 @@ impl<IO> Driver<IO> {
         let session = Session {
             dep_graph: self.dependencies,
             workspace_root: self.package.path,
+            source_map: self.source_map,
             options: self.config.options,
         };
 

--- a/compiler/lume_session/src/lib.rs
+++ b/compiler/lume_session/src/lib.rs
@@ -13,7 +13,7 @@ use indexmap::IndexMap;
 pub use io::*;
 use lume_architect::{Database, DatabaseContext};
 use lume_errors::DiagCtx;
-use lume_span::{FileName, PackageId, SourceFile};
+use lume_span::{FileName, PackageId, SourceFile, SourceMap};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
@@ -185,6 +185,7 @@ pub struct Session {
     pub options: Options,
     pub workspace_root: PathBuf,
     pub dep_graph: DependencyMap,
+    pub source_map: SourceMap,
 }
 
 unsafe impl Send for Session {}

--- a/crates/lume_metadata/Cargo.toml
+++ b/crates/lume_metadata/Cargo.toml
@@ -12,6 +12,7 @@ lume_errors = { path = "../lume_errors" }
 lume_hir = { path = "../../compiler/lume_hir" }
 lume_infer = { path = "../../compiler/lume_infer" }
 lume_session = { path = "../../compiler/lume_session" }
+lume_span = { path = "../lume_span" }
 
 ciborium = { version = "=0.2.2" }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/lume_metadata/src/lib.rs
+++ b/crates/lume_metadata/src/lib.rs
@@ -4,6 +4,7 @@ use lume_errors::{MapDiagnostic, Result, SimpleDiagnostic};
 use lume_hir::map::Map;
 use lume_infer::TyInferCtx;
 use lume_session::{Package, PackageHash};
+use lume_span::SourceMap;
 use serde::{Deserialize, Serialize};
 
 /// Defines the file extension to use for metadata library files.
@@ -42,6 +43,17 @@ impl PackageHeader {
 #[derive(Serialize, Deserialize)]
 pub struct PackageMetadata {
     pub header: PackageHeader,
+
+    /// Source file information for all the sources directly within the package
+    /// source tree.
+    ///
+    /// NOTE: this field MUST appear before any [Location] fields, even nested
+    /// ones. The source map must be deserialized first, in order for
+    /// deduplicated [Location] keys to be resolved correctly. See
+    /// more in the [`lume_span::source::serialize`] module.
+    ///
+    /// [Location]: lume_span::Location
+    pub source_map: SourceMap,
     pub hir: Map,
 }
 
@@ -53,6 +65,7 @@ impl PackageMetadata {
 
         Self {
             header,
+            source_map: tcx.gcx().session.source_map.clone(),
             hir: public_hir,
         }
     }
@@ -133,9 +146,9 @@ pub fn read_metadata_header<P: AsRef<Path>>(metadata_path: P) -> Result<Option<P
     Ok(Some(header))
 }
 
-/// Writes the serialized representation of `metadata` to disk within the
-/// metadata directory defined by `gcx` (via
-/// [`GlobalCtx::obj_metadata_path()`]).
+/// Writes the serialized representation of `metadata` to disk within the given
+/// metadata directory. The name of the written file is determined by
+/// [`metadata_filename_of`].
 pub fn write_metadata_object<P: AsRef<Path>>(metadata_directory: P, metadata: &PackageMetadata) -> Result<()> {
     // Ensure the parent directory exists first.
     let metadata_directory = metadata_directory.as_ref();
@@ -176,6 +189,9 @@ fn serialize_metadata<W: std::io::Write>(
     let mut header = Vec::<u8>::with_capacity(64);
     ciborium::into_writer(&metadata.header, &mut header)?;
 
+    let mut source_map = Vec::<u8>::new();
+    ciborium::into_writer(&metadata.source_map, &mut source_map)?;
+
     let mut hir = Vec::<u8>::new();
     ciborium::into_writer(&metadata.hir, &mut hir)?;
 
@@ -183,6 +199,9 @@ fn serialize_metadata<W: std::io::Write>(
 
     writer.write_all(&usize::to_ne_bytes(header.len()))?;
     writer.write_all(&header)?;
+
+    writer.write_all(&usize::to_ne_bytes(source_map.len()))?;
+    writer.write_all(&source_map)?;
 
     writer.write_all(&usize::to_ne_bytes(hir.len()))?;
     writer.write_all(&hir)?;
@@ -209,9 +228,14 @@ fn deserialize_metadata<R: std::io::Read>(
     reader: &mut R,
 ) -> std::result::Result<PackageMetadata, Box<dyn std::error::Error>> {
     let header = deserialize_metadata_header(reader)?;
+    let source_map = deserialize_item::<R, SourceMap>(reader)?;
     let hir = deserialize_item::<R, Map>(reader)?;
 
-    Ok(PackageMetadata { header, hir })
+    Ok(PackageMetadata {
+        header,
+        source_map,
+        hir,
+    })
 }
 
 /// Deserialize a single "item" from the given reader.

--- a/crates/lume_span/src/source/mod.rs
+++ b/crates/lume_span/src/source/mod.rs
@@ -5,6 +5,8 @@
 //! spans are required to print useful diagnostics to the user - at least if
 //! source code is needed.
 
+pub mod serialize;
+
 use std::hash::Hash;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -157,7 +159,7 @@ impl error_snippet::Source for SourceFile {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Location {
     /// Defines the original source code.
     pub file: Arc<SourceFile>,
@@ -289,7 +291,7 @@ pub struct InvalidSourceFile {
 
 /// Defines a source map, which maps source file IDs to their corresponding
 /// source files.
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct SourceMap {
     /// Defines all the source files within the mapping.
     files: IndexMap<SourceFileId, Arc<SourceFile>>,
@@ -341,5 +343,13 @@ impl SourceMap {
     /// Iterates all the files within the map.
     pub fn iter(&self) -> impl Iterator<Item = &Arc<SourceFile>> {
         self.files.values()
+    }
+}
+
+impl FromIterator<Arc<SourceFile>> for SourceMap {
+    fn from_iter<T: IntoIterator<Item = Arc<SourceFile>>>(iter: T) -> Self {
+        Self {
+            files: iter.into_iter().map(|file| (file.id, file)).collect(),
+        }
     }
 }

--- a/crates/lume_span/src/source/serialize.rs
+++ b/crates/lume_span/src/source/serialize.rs
@@ -1,0 +1,155 @@
+//! This module handles deserialization of source files.
+//!
+//! In the Lume compiler, source files are shared using [`Arc`] to save memory.
+//! But, this leads to a ton of duplication when serialization metadata to disk,
+//! since every [`Location`] struct would otherwise contain a duplicate copy of
+//! the entire source file.
+//!
+//! To avoid this, the metadata contains a separate entry for source files which
+//! are read before the rest of the location entries. This source map is stored
+//! in a global source map. Location entries are then just deserialized from
+//! their source IDs and retrieved from the global.
+
+use std::ops::Range;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use indexmap::IndexMap;
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize};
+
+use crate::source::Location;
+use crate::{SourceFile, SourceFileId, SourceMap};
+
+/// Global state for deserialized source maps. This value is populated when any
+/// [`SourceMap`] is deserialized, either by reading `.mlib` metadata files or
+/// manually. When additional [`SourceMap`] instances are deserialized, this
+/// value will be expanded to contain the new source files.
+static DESERIALIZE_STATE: LazyLock<Mutex<SourceMap>> = LazyLock::new(|| Mutex::new(SourceMap::new()));
+
+fn source_from_state(id: SourceFileId) -> Arc<SourceFile> {
+    let state = (*DESERIALIZE_STATE)
+        .try_lock()
+        .expect("failed to lock deserialization state - is another thread trying to deserialize?");
+
+    state
+        .files
+        .get(&id)
+        .unwrap_or_else(|| panic!("failed to find source file {id:?}"))
+        .clone()
+}
+
+impl Serialize for SourceMap {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        <IndexMap<SourceFileId, Arc<SourceFile>> as Serialize>::serialize(&self.files, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SourceMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let files = <IndexMap<SourceFileId, Arc<SourceFile>> as Deserialize>::deserialize(deserializer)?;
+        let mut state = (*DESERIALIZE_STATE)
+            .try_lock()
+            .expect("failed to lock deserialization state - is another thread trying to deserialize?");
+
+        files.clone_into(&mut state.files);
+
+        Ok(Self { files })
+    }
+}
+
+impl serde::Serialize for Location {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("Location", 2)?;
+        s.serialize_field("file", &self.file.id)?;
+        s.serialize_field("index", &self.index)?;
+        s.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Location {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            File,
+            Index,
+        }
+
+        struct LocationVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for LocationVisitor {
+            type Value = Location;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct Location")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Location, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let file: SourceFileId = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+
+                let index: Range<usize> = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+
+                Ok(Location {
+                    file: source_from_state(file),
+                    index,
+                })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Location, V::Error>
+            where
+                V: serde::de::MapAccess<'de>,
+            {
+                let mut file: Option<SourceFileId> = None;
+                let mut index: Option<Range<usize>> = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::File => {
+                            if file.is_some() {
+                                return Err(serde::de::Error::duplicate_field("file"));
+                            }
+
+                            file = Some(map.next_value()?);
+                        }
+                        Field::Index => {
+                            if index.is_some() {
+                                return Err(serde::de::Error::duplicate_field("index"));
+                            }
+
+                            index = Some(map.next_value()?);
+                        }
+                    }
+                }
+
+                let file = file.ok_or_else(|| serde::de::Error::missing_field("file"))?;
+                let index = index.ok_or_else(|| serde::de::Error::missing_field("index"))?;
+
+                Ok(Location {
+                    file: source_from_state(file),
+                    index,
+                })
+            }
+        }
+
+        deserializer.deserialize_struct("Location", &["file", "index"], LocationVisitor)
+    }
+}


### PR DESCRIPTION
This is one of those things I should've been aware of when I wrote the original implementation of `mlib`, but I just didn't realize. I was probably tired or something.

The current problem with the `mlib` files originates from the `Location` structures. Every single place where a specific index within a source file is referenced, `Location` encodes that information, in a shared, interned way. That is to say, it's used a lot!

`Location` essentially looks like this:
```rs
pub struct Location {
    pub file: Arc<SourceFile>,
    pub index: Range<usize>,
}
```
where `SourceFile` contains the entire source content of the relevant file. This is fine, since the source content would rarely change. **Except** when serializing `Location` structures! Because then, `Arc<SourceFile>` is handled just like a regular `SourceFile `, which means the content is serialized *every time* any `Location` is serialized - **which is a lot.**  

In summary, this PR reduces the file size of metadata files drastically. On my system, `std` **shrunk from 186 MB to 1.8 MB (10.3x savings)**.