### PR TITLE
feat(hir/match): allow casting match results to node references

### DIFF
--- a/compiler/lume_hir/src/matcher/cast.rs
+++ b/compiler/lume_hir/src/matcher/cast.rs
@@ -1,0 +1,187 @@
+/// Simple type conversion of reference types, allowing for downcasting to a
+/// specific type, or casting into a contained field reference.
+///
+/// This is used for casting [`Node`] references into their specific
+/// variant types, such as [`Statement`], [`Expression`], and so
+/// on. This also allows for chaining, such as casting [`Node`] into
+/// [`VariableDeclaration`] ([`Node`] into [`Statement`] into
+/// [`VariableDeclaration`]).
+///
+/// [`Node`]: crate::Node
+/// [`Statement`]: crate::Statement
+/// [`Expression`]: crate::Expression
+/// [`VariableDeclaration`]: crate::VariableDeclaration
+pub trait Cast<T> {
+    /// Performs the cast.
+    ///
+    /// If `self` does not support casting into `T`, returns [`None`].
+    fn cast(&self) -> Option<&T>;
+}
+
+macro_rules! impl_cast_node {
+    ($(
+        $enum_variant:ident => $target_type:ty
+    ),*) => {
+        $(
+            impl Cast<$target_type> for crate::Node {
+                fn cast(&self) -> Option<&$target_type> {
+                    match self {
+                        crate::Node::$enum_variant(node) => Some(node),
+                        _ => None,
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_cast_node! {
+    Function => crate::FunctionDefinition,
+    Type => crate::TypeDefinition,
+    TraitImpl => crate::TraitImplementation,
+    Impl => crate::Implementation,
+    Field => crate::Field,
+    Parameter => crate::Parameter,
+    Method => crate::MethodDefinition,
+    TraitMethodDef => crate::TraitMethodDefinition,
+    TraitMethodImpl => crate::TraitMethodImplementation,
+    Pattern => crate::Pattern,
+    Statement => crate::Statement,
+    Expression => crate::Expression
+}
+
+impl Cast<crate::EnumDefinition> for crate::Node {
+    fn cast(&self) -> Option<&crate::EnumDefinition> {
+        let def: &crate::TypeDefinition = self.cast()?;
+
+        match def {
+            crate::TypeDefinition::Enum(node) => Some(node),
+            _ => None,
+        }
+    }
+}
+
+impl Cast<crate::StructDefinition> for crate::Node {
+    fn cast(&self) -> Option<&crate::StructDefinition> {
+        let def: &crate::TypeDefinition = self.cast()?;
+
+        match def {
+            crate::TypeDefinition::Struct(node) => Some(node),
+            _ => None,
+        }
+    }
+}
+
+impl Cast<crate::TraitDefinition> for crate::Node {
+    fn cast(&self) -> Option<&crate::TraitDefinition> {
+        let def: &crate::TypeDefinition = self.cast()?;
+
+        match def {
+            crate::TypeDefinition::Trait(node) => Some(node),
+            _ => None,
+        }
+    }
+}
+
+impl Cast<crate::TypeParameter> for crate::Node {
+    fn cast(&self) -> Option<&crate::TypeParameter> {
+        let def: &crate::TypeDefinition = self.cast()?;
+
+        match def {
+            crate::TypeDefinition::TypeParameter(node) => Some(node),
+            _ => None,
+        }
+    }
+}
+
+macro_rules! impl_try_from_stmt {
+    ($(
+        $enum_variant:ident => $target_type:ty
+    ),*) => {
+        $(
+            impl Cast<$target_type> for crate::Node {
+                fn cast(&self) -> Option<&$target_type> {
+                    let stmt: &crate::Statement = self.cast()?;
+
+                    match &stmt.kind {
+                        crate::StatementKind::$enum_variant(node) => Some(node),
+                        _ => None,
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_stmt! {
+    Variable => crate::VariableDeclaration,
+    Break => crate::Break,
+    Continue => crate::Continue,
+    Final => crate::Final,
+    Return => crate::Return,
+    InfiniteLoop => crate::InfiniteLoop
+}
+
+macro_rules! impl_try_from_expr {
+    ($(
+        $enum_variant:ident => $target_type:ty
+    ),*) => {
+        $(
+            impl Cast<$target_type> for crate::Node {
+                fn cast(&self) -> Option<&$target_type> {
+                    let expr: &crate::Expression = self.cast()?;
+
+                    match &expr.kind {
+                        crate::ExpressionKind::$enum_variant(node) => Some(node),
+                        _ => None,
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_expr! {
+    Assignment => crate::Assignment,
+    Cast => crate::Cast,
+    Construct => crate::Construct,
+    Deref => crate::DerefExpr,
+    Ref => crate::RefExpr,
+    StaticCall => crate::StaticCall,
+    InstanceCall => crate::InstanceCall,
+    IntrinsicCall => crate::IntrinsicCall,
+    If => crate::If,
+    Is => crate::Is,
+    Literal => crate::Literal,
+    Member => crate::Member,
+    Scope => crate::Scope,
+    Switch => crate::Switch,
+    Variable => crate::Variable,
+    Variant => crate::Variant
+}
+
+macro_rules! impl_try_from_pattern {
+    ($(
+        $enum_variant:ident => $target_type:ty
+    ),*) => {
+        $(
+            impl Cast<$target_type> for crate::Node {
+                fn cast(&self) -> Option<&$target_type> {
+                    let pat: &crate::Pattern = self.cast()?;
+
+                    match &pat.kind {
+                        crate::PatternKind::$enum_variant(node) => Some(node),
+                        _ => None,
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_pattern! {
+    Literal => crate::LiteralPattern,
+    Identifier => crate::IdentifierPattern,
+    Variant => crate::VariantPattern,
+    Wildcard => crate::WildcardPattern
+}

--- a/compiler/lume_hir/src/matcher/expr.rs
+++ b/compiler/lume_hir/src/matcher/expr.rs
@@ -16,6 +16,188 @@ lumec_matchers! {
         }
     }
 
+    /// Matches all assignment expressions (`as`).
+    matcher assignment(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Assignment;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Assignment(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all cast expressions (`as`).
+    matcher cast(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Cast;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Cast(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all construct expressions.
+    matcher construct(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Construct;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Construct(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all dereference expressions (`*`).
+    matcher deref_expr(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = DerefExpr;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Deref(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all reference expressions (`&`).
+    matcher ref_expr(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = RefExpr;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Ref(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all intrinsic call expressions.
+    matcher intrinsic_call(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = IntrinsicCall;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::IntrinsicCall(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all instance call expressions.
+    matcher instance_call(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = InstanceCall;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::InstanceCall(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all static call expressions.
+    matcher static_call(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = StaticCall;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::StaticCall(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all `if` expressions.
+    matcher if_expr(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = If;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::If(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all `is` expressions.
+    matcher is(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Is;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Is(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all literal expressions.
+    matcher literal(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Literal;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Literal(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all member expressions.
+    matcher member(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Member;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Member(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Matches all scope expressions.
+    matcher scope(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Scope;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Scope(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+
     /// Matches all variable references.
     matcher var_reference(predicates) -> bool {
         type Parent = Expression;
@@ -30,6 +212,22 @@ lumec_matchers! {
         }
     }
 
+    /// Matches all variant expressions.
+    matcher variant(predicates) -> bool {
+        type Parent = Expression;
+        type Subject = Variant;
+
+        fn satisfies(&self, hir: &Map, subject: &Self::Subject, bindings: &mut Bindings) -> bool {
+            if let ExpressionKind::Variant(subject) = &subject.kind {
+                Predicate::satisfies(&self.predicates, hir, subject, bindings)
+            } else {
+                false
+            }
+        }
+    }
+}
+
+lumec_matchers! {
     /// Matches all switch expressions.
     matcher switch(predicates) -> bool {
         type Parent = Expression;

--- a/compiler/lume_hir/src/matcher/mod.rs
+++ b/compiler/lume_hir/src/matcher/mod.rs
@@ -1,29 +1,34 @@
+pub mod cast;
+pub mod expr;
+pub mod item;
+pub mod pat;
+pub mod stmt;
+pub mod string;
+
 use std::collections::HashMap;
 use std::ops::ControlFlow;
 
+pub use expr::*;
+pub use item::*;
+pub use pat::*;
+pub use stmt::*;
+pub use string::*;
+
 use crate::visitor::traverse_node;
 use crate::*;
-
-pub mod expr;
-pub use expr::*;
-
-pub mod item;
-pub use item::*;
-
-pub mod pat;
-pub use pat::*;
-
-pub mod stmt;
-pub use stmt::*;
-
-pub mod string;
-pub use string::*;
 
 /// Performs a global match against all nodes in the given HIR map.
 ///
 /// Searches the HIR map for nodes which satisfy `matcher` and calls `callback`
 /// for each match. After each match, the return value of `callback` defines
 /// whether the matcher will continue or stop.
+///
+/// # Returns
+///
+/// If a match is found and the callback returns [`ControlFlow::Break`], the
+/// contained value is returned as [`Some`] from this function. If no match is
+/// found or if the callback does not return [`ControlFlow::Break`], returns
+/// [`None`].
 ///
 /// # Examples
 ///
@@ -41,20 +46,20 @@ pub use string::*;
 ///         &mut |result| {
 ///             functions.push(result.bound_node("func").unwrap().id());
 ///
-///             ControlFlow::Continue(())
+///             ControlFlow::<()>::Continue(())
 ///         }
 ///     );
 ///
 ///     functions
 /// }
 /// ```
-pub fn find_matches<'hir>(
+pub fn find_matches<'hir, R>(
     hir: &'hir Map,
     matcher: &dyn Predicate<Subject = Node>,
-    callback: &mut dyn FnMut(&Results<'hir>) -> ControlFlow<()>,
-) {
+    callback: &mut dyn FnMut(&Results<'hir>) -> ControlFlow<R>,
+) -> Option<R> {
     let mut visitor = PredicateVisitor { hir, matcher, callback };
-    let _ = traverse(hir, &mut visitor);
+    traverse(hir, &mut visitor).break_value()
 }
 
 /// Performs a narrowed match against all nodes in the given HIR map, which are
@@ -63,6 +68,13 @@ pub fn find_matches<'hir>(
 /// Searches the HIR map for nodes which satisfy `matcher` and calls `callback`
 /// for each match. After each match, the return value of `callback` defines
 /// whether the matcher will continue or stop.
+///
+/// # Returns
+///
+/// If a match is found and the callback returns [`ControlFlow::Break`], the
+/// contained value is returned as [`Some`] from this function. If no match is
+/// found or if the callback does not return [`ControlFlow::Break`], returns
+/// [`None`].
 ///
 /// # Examples
 ///
@@ -81,7 +93,7 @@ pub fn find_matches<'hir>(
 ///         &mut |result| {
 ///             methods.push(result.bound_node("func").unwrap().id());
 ///
-///             ControlFlow::Continue(())
+///             ControlFlow::<()>::Continue(())
 ///         },
 ///         impl_node
 ///     );
@@ -89,14 +101,14 @@ pub fn find_matches<'hir>(
 ///     methods
 /// }
 /// ```
-pub fn find_matches_in<'hir>(
+pub fn find_matches_in<'hir, R>(
     hir: &'hir Map,
     matcher: &dyn Predicate<Subject = Node>,
-    callback: &mut dyn FnMut(&Results<'hir>) -> ControlFlow<()>,
+    callback: &mut dyn FnMut(&Results<'hir>) -> ControlFlow<R>,
     entrypoint: &Node,
-) {
+) -> Option<R> {
     let mut visitor = PredicateVisitor { hir, matcher, callback };
-    let _ = traverse_node(hir, &mut visitor, entrypoint);
+    traverse_node(hir, &mut visitor, entrypoint).break_value()
 }
 
 /// Performs a global match against all nodes in the given HIR map.
@@ -108,19 +120,81 @@ pub fn find_matches_in<'hir>(
 /// This is equivalent to:
 /// ```ignore
 /// find_matches(hir, matcher, &mut |result| {
+///     let result = (callback)(result);
+///     ControlFlow::Break(result)
+/// })
+/// ```
+pub fn find_first_match<'hir, R>(
+    hir: &'hir Map,
+    matcher: &dyn Predicate<Subject = Node>,
+    callback: &mut dyn FnMut(&Results<'hir>) -> R,
+) -> Option<R> {
+    find_matches(hir, matcher, &mut |result| {
+        let result = (callback)(result);
+        ControlFlow::Break(result)
+    })
+}
+
+/// Performs a global match against all nodes in the given HIR map.
+///
+/// Searches the HIR map for nodes which satisfy `matcher` and calls `callback`
+/// whenever a match is found. The matcher will continue searching until all
+/// nodes have been checked.
+///
+/// This is equivalent to:
+/// ```ignore
+/// find_matches(hir, matcher, &mut |result| {
 ///     (callback)(result);
-///     ControlFlow::Break(())
+///     ControlFlow::Continue(())
 /// });
 /// ```
-pub fn find_first_match<'hir>(
+pub fn find_all_matches<'hir>(
     hir: &'hir Map,
     matcher: &dyn Predicate<Subject = Node>,
     callback: &mut dyn FnMut(&Results<'hir>),
 ) {
     find_matches(hir, matcher, &mut |result| {
         (callback)(result);
-        ControlFlow::Break(())
+
+        ControlFlow::<()>::Continue(())
     });
+}
+
+/// Performs a global match against all nodes in the given HIR map, which are
+/// descendants of the given entrypoint node.
+///
+/// Searches the HIR map for nodes which satisfy `matcher` and calls `callback`
+/// whenever a match is found. The matcher will continue searching until all
+/// nodes have been checked.
+///
+/// This is equivalent to:
+/// ```ignore
+/// find_matches_in(
+///     hir,
+///     matcher,
+///     &mut |result| {
+///         (callback)(result);
+///         ControlFlow::Continue(())
+///     },
+///     entrypoint
+/// );
+/// ```
+pub fn find_all_matches_in<'hir>(
+    hir: &'hir Map,
+    matcher: &dyn Predicate<Subject = Node>,
+    callback: &mut dyn FnMut(&Results<'hir>),
+    entrypoint: &Node,
+) {
+    find_matches_in(
+        hir,
+        matcher,
+        &mut |result| {
+            (callback)(result);
+
+            ControlFlow::<()>::Continue(())
+        },
+        entrypoint,
+    );
 }
 
 /// Holds the bindings for a given match operation.
@@ -162,14 +236,28 @@ impl Results<'_> {
     /// Gets the node associated with the given binding, if any. Otherwise, if
     /// no binding was found for the current match, returns [`None`].
     #[inline]
-    pub fn bound_node(&self, key: &'static str) -> Option<&'_ Node> {
+    pub fn bound_node(&self, key: &'static str) -> Option<&Node> {
         self.bindings.nodes.get(&key).map(|id| self.hir.node(*id).unwrap())
+    }
+
+    /// Gets the node associated with the given binding and attempts to cast it
+    /// to the type `T`.
+    ///
+    /// If no binding was found, returns [`None`]. Similarly, if the binding
+    /// does not support casting into `T`, returns [`None`].
+    #[inline]
+    pub fn cast_node_as<T>(&self, key: &'static str) -> Option<&T>
+    where
+        Node: cast::Cast<T>,
+    {
+        self.bound_node(key)
+            .and_then(|node| <Node as cast::Cast<T>>::cast(node))
     }
 
     /// Gets the type associated with the given type binding, if any. Otherwise,
     /// if no binding was found for the current match, returns [`None`].
     #[inline]
-    pub fn bound_type(&self, key: &'static str) -> Option<&'_ Type> {
+    pub fn bound_type(&self, key: &'static str) -> Option<&Type> {
         self.bindings.types.get(&key).map(|id| self.hir.type_(*id).unwrap())
     }
 }
@@ -303,14 +391,14 @@ impl PredicateBindTypeExt<Type> for PredicateBox<Type> {
     }
 }
 
-struct PredicateVisitor<'a, 'hir> {
+struct PredicateVisitor<'a, 'hir, R> {
     hir: &'hir Map,
     matcher: &'a dyn Predicate<Subject = Node>,
-    callback: &'a mut dyn FnMut(&Results<'hir>) -> ControlFlow<()>,
+    callback: &'a mut dyn FnMut(&Results<'hir>) -> ControlFlow<R>,
 }
 
-impl Visitor for PredicateVisitor<'_, '_> {
-    type Break = ();
+impl<R> Visitor for PredicateVisitor<'_, '_, R> {
+    type Break = R;
 
     fn visit_node(&mut self, node: &Node) -> std::ops::ControlFlow<Self::Break> {
         let mut bindings = Bindings::default();

--- a/compiler/lume_hir/tests/matcher_item.rs
+++ b/compiler/lume_hir/tests/matcher_item.rs
@@ -22,13 +22,11 @@ fn match_all_items_in_root() {
     let mut called_with = Cell::new(Vec::with_capacity(3));
 
     find_matches(&hir, &function([]).bind("func"), &mut |result| {
-        let lume_hir::Node::Function(func) = result.bound_node("func").unwrap() else {
-            unreachable!();
-        };
+        let func = result.cast_node_as::<lume_hir::FunctionDefinition>("func").unwrap();
 
         called_with.get_mut().push(func.path().to_string());
 
-        ControlFlow::Continue(())
+        ControlFlow::<()>::Continue(())
     });
 
     assert_eq!(called_with.into_inner(), vec!["foo", "bar", "baz"]);
@@ -69,14 +67,10 @@ fn match_with_outside_state() {
 
     let mut matches = Vec::new();
 
-    find_matches(&hir, &function([]).bind("func"), &mut |result| {
-        let lume_hir::Node::Function(func) = result.bound_node("func").unwrap() else {
-            unreachable!();
-        };
+    find_all_matches(&hir, &function([]).bind("func"), &mut |result| {
+        let func = result.cast_node_as::<lume_hir::FunctionDefinition>("func").unwrap();
 
         matches.push(func.path().to_string());
-
-        ControlFlow::Continue(())
     });
 
     assert_eq!(matches, vec!["foo", "bar"]);
@@ -93,7 +87,7 @@ fn match_filter_node() {
     ",
     );
 
-    find_matches(
+    find_all_matches(
         &hir,
         &statement([var_decl([filter(
             |var_decl: &lume_hir::VariableDeclaration| var_decl.name.as_str() == "b",
@@ -101,17 +95,9 @@ fn match_filter_node() {
         )])])
         .bind("decl"),
         &mut |result| {
-            let lume_hir::Node::Statement(stmt) = result.bound_node("decl").unwrap() else {
-                unreachable!();
-            };
-
-            let lume_hir::StatementKind::Variable(var_decl) = &stmt.kind else {
-                unreachable!();
-            };
+            let var_decl = result.cast_node_as::<lume_hir::VariableDeclaration>("decl").unwrap();
 
             assert_eq!(var_decl.name.as_str(), "b");
-
-            ControlFlow::Continue(())
         },
     );
 }
@@ -134,22 +120,16 @@ fn match_optional_bindings() {
         ]).bind("var_decl")
     ]);
 
-    find_matches(&hir, &p, &mut |result| {
-        let lume_hir::Node::Statement(stmt) = result.bound_node("var_decl").unwrap() else {
-            unreachable!();
-        };
-
-        let lume_hir::StatementKind::Variable(var_decl) = &stmt.kind else {
-            unreachable!();
-        };
+    find_all_matches(&hir, &p, &mut |result| {
+        let var_decl = result
+            .cast_node_as::<lume_hir::VariableDeclaration>("var_decl")
+            .unwrap();
 
         match var_decl.name.as_str() {
             "a" => assert!(result.bound_type("var_type").is_none()),
             "b" => assert!(result.bound_type("var_type").is_some()),
             _ => unreachable!(),
         }
-
-        ControlFlow::Continue(())
     });
 }
 
@@ -177,21 +157,13 @@ fn match_inside_node() {
         })
         .unwrap();
 
-    find_matches_in(
+    find_all_matches_in(
         &hir,
         &statement([var_decl([])]).bind("decl"),
         &mut |result| {
-            let lume_hir::Node::Statement(stmt) = result.bound_node("decl").unwrap() else {
-                unreachable!();
-            };
-
-            let lume_hir::StatementKind::Variable(var_decl) = &stmt.kind else {
-                unreachable!();
-            };
+            let var_decl = result.cast_node_as::<lume_hir::VariableDeclaration>("decl").unwrap();
 
             assert_eq!(var_decl.name.as_str(), "a");
-
-            ControlFlow::Continue(())
         },
         foo_node,
     );
@@ -209,17 +181,13 @@ fn match_fn_definitions() {
     );
 
     find_first_match(&hir, &function([]).bind("func"), &mut |result| {
-        let lume_hir::Node::Function(func) = result.bound_node("func").unwrap() else {
-            unreachable!();
-        };
+        let func = result.cast_node_as::<lume_hir::FunctionDefinition>("func").unwrap();
 
         assert_eq!(func.signature.name.to_string(), "foo");
     });
 
     find_first_match(&hir, &function([has_documentation([])]).bind("func"), &mut |result| {
-        let lume_hir::Node::Function(func) = result.bound_node("func").unwrap() else {
-            unreachable!();
-        };
+        let func = result.cast_node_as::<lume_hir::FunctionDefinition>("func").unwrap();
 
         assert_eq!(func.signature.name.to_string(), "bar");
     });
@@ -241,17 +209,13 @@ fn match_method_definitions() {
     );
 
     find_first_match(&hir, &method([]).bind("func"), &mut |result| {
-        let lume_hir::Node::Method(func) = result.bound_node("func").unwrap() else {
-            unreachable!();
-        };
+        let func = result.cast_node_as::<lume_hir::MethodDefinition>("func").unwrap();
 
         assert_eq!(func.signature.name.to_string(), "foo");
     });
 
     find_first_match(&hir, &method([has_documentation([])]).bind("func"), &mut |result| {
-        let lume_hir::Node::Method(func) = result.bound_node("func").unwrap() else {
-            unreachable!();
-        };
+        let func = result.cast_node_as::<lume_hir::MethodDefinition>("func").unwrap();
 
         assert_eq!(func.signature.name.to_string(), "bar");
     });

--- a/compiler/lume_hir/tests/matcher_pat.rs
+++ b/compiler/lume_hir/tests/matcher_pat.rs
@@ -2,8 +2,6 @@ pub mod fixtures {
     pub mod matcher;
 }
 
-use std::ops::ControlFlow;
-
 use fixtures::matcher::fixture_as_hir;
 use lume_hir::matcher::*;
 
@@ -34,12 +32,10 @@ fn match_patterns_in_switch() {
         ])
     ]);
 
-    find_matches(&hir, &p, &mut |result| {
+    find_all_matches(&hir, &p, &mut |result| {
         assert!(result.bound_node("ident_block").is_some());
         assert!(result.bound_node("literal_block").is_some());
         assert!(result.bound_node("variant_block").is_some());
         assert!(result.bound_node("wildcard_block").is_some());
-
-        ControlFlow::Continue(())
     });
 }

--- a/compiler/lume_hir/tests/matcher_stmt.rs
+++ b/compiler/lume_hir/tests/matcher_stmt.rs
@@ -9,7 +9,7 @@ use lume_hir::matcher::*;
 fn match_no_statements() {
     let hir = fixture_as_hir("fn foo() {}");
 
-    find_matches(&hir, &statement([]), &mut |_result| {
+    find_matches::<()>(&hir, &statement([]), &mut |_result| {
         panic!("this should not be called!")
     });
 }


### PR DESCRIPTION
As a quality-of-life improvement, this PR adds a `cast_node_as` method to `Results`, which allows you to skip the node traversal of each result.

**Before:**
```rust
let lume_hir::Node::Statement(stmt) = result.bound_node("decl").unwrap() else {
    unreachable!();
};

let lume_hir::StatementKind::Variable(var_decl) = &stmt.kind else {
    unreachable!();
};
```

**After:**
```rust
let var_decl = result.cast_node_as::<lume_hir::VariableDeclaration>("decl").unwrap();
```